### PR TITLE
chore: Item 9 — retire ReScript guidance → AffineScript

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,7 +43,7 @@ The following files in `.machine_readable/` contain structured project metadata:
 | Bun | Deno |
 | pnpm/yarn | Deno |
 | Go | Rust |
-| Python | Julia/Rust/ReScript |
+| Python | Julia/Rust/AffineScript |
 | Java/Kotlin | Rust/Tauri/Dioxus |
 | Swift | Tauri/Dioxus |
 | React Native | Tauri/Dioxus |

--- a/.github/workflows/language-policy.yml
+++ b/.github/workflows/language-policy.yml
@@ -11,7 +11,7 @@ jobs:
           # Block new Python files (except SaltStack)
           NEW_PY=$(git diff --name-only --diff-filter=A HEAD~1 2>/dev/null | grep -E '\.py$' | grep -v 'salt' || true)
           if [ -n "$NEW_PY" ]; then
-            echo "❌ New Python files detected. Use Rust or ReScript instead."
+            echo "❌ New Python files detected. Use Rust or AffineScript instead."
             echo "$NEW_PY"
             exit 1
           fi

--- a/.github/workflows/rsr-antipattern.yml
+++ b/.github/workflows/rsr-antipattern.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for tsconfig
         run: |
           if [ -f "tsconfig.json" ]; then
-            echo "❌ tsconfig.json detected - use ReScript instead"
+            echo "❌ tsconfig.json detected - use AffineScript instead"
             exit 1
           fi
           echo "✅ No tsconfig.json"

--- a/.github/workflows/ts-blocker.yml
+++ b/.github/workflows/ts-blocker.yml
@@ -18,7 +18,7 @@ jobs:
           NEW_JS=$(git diff --name-only --diff-filter=A HEAD~1 2>/dev/null | grep -E '\.(js|jsx)$' | grep -v '\.res\.js$' | grep -v '\.gen\.' | grep -v 'node_modules' || true)
           
           if [ -n "$NEW_TS" ] || [ -n "$NEW_JS" ]; then
-            echo "❌ New TS/JS files detected. Use ReScript instead."
+            echo "❌ New TS/JS files detected. Use AffineScript instead."
             [ -n "$NEW_TS" ] && echo "$NEW_TS"
             [ -n "$NEW_JS" ] && echo "$NEW_JS"
             exit 1

--- a/.migration/PYTHON_TO_RUST_RESCRIPT.md
+++ b/.migration/PYTHON_TO_RUST_RESCRIPT.md
@@ -1,4 +1,4 @@
-# Python → Rust/ReScript Migration Guide
+# Python → Rust/AffineScript Migration Guide
 
 ## Policy
 This repo contains Python code that should be migrated to:

--- a/playground/.claude/CLAUDE.md
+++ b/playground/.claude/CLAUDE.md
@@ -43,7 +43,7 @@ The following files in `.machine_readable/` contain structured project metadata:
 | Bun | Deno |
 | pnpm/yarn | Deno |
 | Go | Rust |
-| Python | Julia/Rust/ReScript |
+| Python | Julia/Rust/AffineScript |
 | Java/Kotlin | Rust/Tauri/Dioxus |
 | Swift | Tauri/Dioxus |
 | React Native | Tauri/Dioxus |

--- a/playground/.github/workflows/language-policy.yml
+++ b/playground/.github/workflows/language-policy.yml
@@ -11,7 +11,7 @@ jobs:
           # Block new Python files (except SaltStack)
           NEW_PY=$(git diff --name-only --diff-filter=A HEAD~1 2>/dev/null | grep -E '\.py$' | grep -v 'salt' || true)
           if [ -n "$NEW_PY" ]; then
-            echo "❌ New Python files detected. Use Rust or ReScript instead."
+            echo "❌ New Python files detected. Use Rust or AffineScript instead."
             echo "$NEW_PY"
             exit 1
           fi

--- a/playground/.github/workflows/rsr-antipattern.yml
+++ b/playground/.github/workflows/rsr-antipattern.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check for TypeScript
         run: |
           if find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules | grep -q .; then
-            echo "❌ TypeScript files detected - use ReScript instead"
+            echo "❌ TypeScript files detected - use AffineScript instead"
             find . -name "*.ts" -o -name "*.tsx" | grep -v node_modules
             exit 1
           fi
@@ -58,7 +58,7 @@ jobs:
       - name: Check for tsconfig
         run: |
           if [ -f "tsconfig.json" ]; then
-            echo "❌ tsconfig.json detected - use ReScript instead"
+            echo "❌ tsconfig.json detected - use AffineScript instead"
             exit 1
           fi
           echo "✅ No tsconfig.json"

--- a/playground/.github/workflows/ts-blocker.yml
+++ b/playground/.github/workflows/ts-blocker.yml
@@ -12,7 +12,7 @@ jobs:
           NEW_JS=$(git diff --name-only --diff-filter=A HEAD~1 2>/dev/null | grep -E '\.(js|jsx)$' | grep -v '\.res\.js$' | grep -v '\.gen\.' | grep -v 'node_modules' || true)
           
           if [ -n "$NEW_TS" ] || [ -n "$NEW_JS" ]; then
-            echo "❌ New TS/JS files detected. Use ReScript instead."
+            echo "❌ New TS/JS files detected. Use AffineScript instead."
             [ -n "$NEW_TS" ] && echo "$NEW_TS"
             [ -n "$NEW_JS" ] && echo "$NEW_JS"
             exit 1

--- a/playground/.migration/PYTHON_TO_RUST_RESCRIPT.md
+++ b/playground/.migration/PYTHON_TO_RUST_RESCRIPT.md
@@ -1,4 +1,4 @@
-# Python → Rust/ReScript Migration Guide
+# Python → Rust/AffineScript Migration Guide
 
 ## Policy
 This repo contains Python code that should be migrated to:


### PR DESCRIPTION
## Estate Tech-Debt — Item 9 (ReScript→AffineScript CI-text sweep)

Rewrites guidance/policy text that recommended **ReScript** as the
TypeScript/Python replacement to recommend **AffineScript** instead, per the
estate language policy (RS/TS/JS → AffineScript → typed-wasm).

### Scope
- ✅ In scope: "use ReScript instead" guidance, `Rust/ReScript` migration-guide
  phrasing, `Rust or ReScript` policy text.
- ⛔ Out of scope (intentionally untouched): any `rescript`-named path/dir and
  ReScript **adapters** (e.g. proven). That work is preserved intact and usable
  for the ReScript ecosystem — only the forward-looking recommendation changes.

Mechanical, reviewed substitution; residual in-scope occurrences verified 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
