### PR TITLE
docs: seed CHANGELOG.md (Keep-a-Changelog format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
+-->
+
+# Changelog
+
+All notable changes to `julia-the-viper` will be documented in this file.
+
+This file is generated from conventional commits by the
+[`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml)
+workflow (`hyperpolymath/standards#206`). Adopt the workflow in this repo's CI to keep this file in sync automatically — see
+[`templates/cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml)
+for the canonical config.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- feat(jtv-cli): add `jtv fmt` subcommand
+- feat(wasm): WASM extern-coproc JS bridge — register_coproc_impl + list_coproc_decls
+- feat(jtv-core): complete C2 reversibility — token-passing reverse/abandon
+- feat(jtv): v2 reversibility C1 Phase 1 — execute_inverse + 7 RV tests
+- feat(jtv): Phase A — Zig FFI + Idris2 ABI lowering pass for live coproc decls
+- feat(coproc): Phase 4 conformance corpus + jtv-cli fix
+- feat(jtv): Phase 2 — PataCL coproc integration (12/12 tests)
+- feat(crg): add crg-grade and crg-badge justfile recipes
+- feat: add comprehensive test suite (339 tests), property/mutation/compat tests
+- feat(v2): wire ReversibleInterpreter into main eval_reverse_block
+
+### Fixed
+
+- fix(ci): pin upload-artifact to valid SHA in hypatia-scan.yml (Refs standards#48) (#16)
+- fix(ci): bump a2ml/k9-validate-action pins to canonical (#14)
+- fix(ci): sync hypatia-scan.yml to canonical (#13)
+- fix(ci): adopt canonical hypatia-scan.yml (#11)
+- fix(ci): Phase-2 fleet submission must not fail the security gate (#10)
+- fix(ci): hypatia-scan workdir (${{ env.HOME }} resolves empty) (#9)
+- fix(ci): hypatia-scan.yml -- --exit-zero + GITHUB_TOKEN (hyperpolymath/hypatia#213) (#6)
+- fix(ci): rsr-antipattern duplicate heredoc + setup-beam ubuntu24 (#7)
+- fix(jtv): sweep .expect("TODO: handle error") — 108 sites cleared
+- fix: replace Obj.magic with type-safe Vscode.get binding
+
+### Documentation
+
+- docs(6a2): update STATE.a2ml — coproc implementation unblocked + done
+- docs(readme): add SPDX header, OSSF and GWF badges
+- docs: add post-audit status report for M5 sweep
+- docs(crg): add Current Grade badge anchor to READINESS.md
+- docs: add TOPOLOGY.md
+- docs: add TEST-NEEDS.md (CRG C)
+
+### CI
+
+- ci: redistribute concurrency-cancel guard to read-only check workflows (#17)
+- ci: bump actions/upload-artifact SHA to current v4 (#5)
+- ci: SHA-pin hyperpolymath validate-actions in dogfood-gate
+- ci: fix workflow-linter YAML parse error + self-flag bug
+- ci(antipattern): fix top-level dir + benchmark/lsp filename matching (#4)
+
+## Pre-history
+
+Prior commits to this file's introduction are recorded in git history but not formally classified into Keep-a-Changelog sections. To backfill, run `git cliff -o CHANGELOG.md` locally using the canonical [`cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml) — this is one-shot mechanical work.
+
+---
+
+<!-- This file was seeded by the 2026-05-26 estate tech-debt audit follow-up (Row-2 Phase 3); see [`hyperpolymath/standards/docs/audits/2026-05-26-estate-documentation-debt.md`](https://github.com/hyperpolymath/standards/blob/main/docs/audits/2026-05-26-estate-documentation-debt.md). -->


### PR DESCRIPTION
## Summary
Adds an initial `CHANGELOG.md` in Keep-a-Changelog format. Recent commits are bucketed into Added/Fixed/Changed/Documentation/CI from their conventional-commit prefixes.

Closes **Row-2 Phase 3** of the 2026-05-26 estate tech-debt audit chain for this repo. The audit ([standards#197](https://github.com/hyperpolymath/standards/pull/197)) flagged 180/279 repos missing CHANGELOG (65% gap).

## Adopting auto-regeneration
For ongoing auto-regeneration, adopt the [`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml) workflow ([standards#206](https://github.com/hyperpolymath/standards/pull/206)) in this repo's CI. Uses the canonical [`templates/cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)