### PR TITLE
ci(k9): exempt standards contractile trident dir from the K9!-magic validator (fix main)

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -92,6 +92,21 @@ jobs:
         with:
           path: '.'
           strict: 'false'
+          # Default ignores + the standards contractile trident dir. The
+          # contractiles' *.k9.ncl are Nickel k9-COMPONENTS (no K9! magic /
+          # hunt-signature, by design — see hyperpolymath/standards), not
+          # K9!-magic service files, so they are out of scope for this
+          # service-file validator. (paths-ignore REPLACES the action default,
+          # so the default entries are reproduced here.)
+          paths-ignore: |
+            vendor/
+            vendored/
+            verified-container-spec/
+            .audittraining/
+            integration/fixtures/
+            test/fixtures/
+            tests/fixtures/
+            .machine_readable/contractiles/
 
       - name: Write summary
         run: |


### PR DESCRIPTION
**Fixes a red `Validate K9 contracts` gate on `main`** introduced when #30 merged.

### Root cause
#30 added `.machine_readable/contractiles/{family}/*.k9.ncl` copied from `hyperpolymath/standards`. jtv's `dogfood-gate.yml` runs `hyperpolymath/k9-validate-action`, which requires a `K9!` magic number + a hunt-level `signature` field. Standards ships those contractile **k9-components** as plain Nickel (no magic/signature) **by design** — they're trident runner-companions, not `K9!`-magic service files. So the validator (correctly, by its own rules) failed with 10 errors.

### Fix
Add `.machine_readable/contractiles/` to the action's `paths-ignore` (which **replaces** the default, so the defaults are reproduced). Restores green without mangling the standards-sourced files (they stay byte-identical to standards). This same exemption will be needed in each repo as the contractile migration rolls out.

### Flag (for an estate issue)
There are effectively **two K9 conventions sharing `.k9.ncl`**: `K9!`-magic service files (what `k9-validate-action` validates) vs Nickel contractile k9-components (what standards' trident ships). These should be reconciled upstream in `hyperpolymath/standards` + `k9-validate-action` (e.g., the action skipping `contractiles/**`, or the components carrying a `K9!`-compatible header).

Workflow-only change; SPDX + permissions + SHA-pin + timeout preserved.

https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742)_