### PR TITLE
ci(hardening): curl|sh installers → download-then-run

### DIFF
--- a/.github/workflows/proof-regression.yml
+++ b/.github/workflows/proof-regression.yml
@@ -60,7 +60,10 @@ jobs:
       - name: Install elan (Lean toolchain manager)
         if: steps.detect.outputs.present == 'true'
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none
+          # Hardened: download the installer to a file, then execute -- avoids
+          # the pipe-to-shell stream-execute pattern (download_then_run audit).
+          curl -sSf -o /tmp/elan-init.sh https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
+          sh /tmp/elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       # NOTE: no actions/cache step — a pinned cache SHA can be auto-failed by
@@ -112,7 +115,7 @@ jobs:
             scheme_bin="$(command -v chez || command -v chezscheme || command -v scheme || echo chez)"
             echo "Using Scheme backend: $scheme_bin"
             # IMPORTANT: download the installer to a FILE. Running it via
-            # `curl | bash` makes its interactive `read SCHEME` consume the
+            # piping the script to bash makes its interactive `read SCHEME` consume the
             # script's own text as the answer. With a file + the Scheme name on
             # stdin, the prompt is answered correctly and later reads hit EOF
             # (taking defaults).

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@
 # Then hands off to `just setup` for project-specific configuration.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/hyperpolymath/julia-the-viper/main/setup.sh | sh
+#   curl -fsSL -o setup.sh https://raw.githubusercontent.com/hyperpolymath/julia-the-viper/main/setup.sh && sh ./setup.sh   # download, inspect, then run
 #   # or after cloning:
 #   ./setup.sh
 #
@@ -140,8 +140,10 @@ install_just() {
     case "$PKG_MGR" in
         dnf)        sudo dnf install -y just ;;
         apt)        sudo apt-get install -y just 2>/dev/null || {
-                        # just not in older apt repos — use installer
-                        curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+                        # just not in older apt repos — use the installer.
+                        # Hardened: download to a file, then execute (no pipe-to-shell).
+                        curl -fsSL -o /tmp/just-install.sh https://just.systems/install.sh
+                        sh /tmp/just-install.sh --to /usr/local/bin
                     } ;;
         pacman)     sudo pacman -S --noconfirm just ;;
         apk)        sudo apk add just ;;
@@ -152,8 +154,9 @@ install_just() {
         guix)       guix install just ;;
         nix)        nix-env -iA nixpkgs.just ;;
         *)
-            info "Using just installer script..."
-            curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+            info "Using just installer script (download-then-run, no pipe-to-shell)..."
+            curl -fsSL -o /tmp/just-install.sh https://just.systems/install.sh
+            sh /tmp/just-install.sh --to /usr/local/bin
             ;;
     esac
 


### PR DESCRIPTION
Part of the workflow-hardening pass. Removes the `curl | sh` pipe-to-shell pattern from the installer sites, clearing the Hypatia `download_then_run` / `shell_download_then_run` findings.

## Done
- **`proof-regression.yml`** — the elan (Lean toolchain) installer now downloads to a file, then executes, instead of `curl … | sh`.
- **`setup.sh`** — the `just` installer (both sites) + the usage one-liner comment switched to download-then-run (download, inspect, then run — on-brand for a security language).
- All explanatory comments reworded so they don't themselves contain the literal the scanner matches (the lesson from the `rsr_check` false-positive earlier in this branch's history).

## Deferred — can't do safely from this session
Both need the `hyperpolymath/standards` reusable contract, which is **out of this session's MCP scope** (the repo is private — `WebFetch` 403 — and `list_repos`/`add_repo` aren't surfaced here). I only have a partial SHA (`524523c`) from STATE, and guessing the filename/full-SHA would break the workflow:
- **`secret-scanner.yml`** (missing_workflow) — needs `hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@<full-SHA>`.
- **`scorecard.yml`** job-permissions — needs the scorecard reusable's permission contract (too-narrow perms break supply-chain scanning).

To finish those I'd need the reusable refs, `standards` added to scope, or for you to apply them.

https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742)_