### PR TITLE
style(effect): rustfmt effect.rs — restore main's Check after #42

### DIFF
--- a/crates/jtv-core/src/effect.rs
+++ b/crates/jtv-core/src/effect.rs
@@ -158,9 +158,8 @@ fn stmt_callees(s: &ControlStmt, out: &mut Vec<String>) {
                 stmt_callees(s, out);
             }
         }
-        ControlStmt::Return(None)
-        | ControlStmt::ReverseToken(_)
-        | ControlStmt::AbandonToken(_) => {}
+        ControlStmt::Return(None) | ControlStmt::ReverseToken(_) | ControlStmt::AbandonToken(_) => {
+        }
     }
 }
 
@@ -301,7 +300,10 @@ mod tests {
         let h = func(
             "h",
             vec![],
-            vec![assign("y", call("g", vec![DataExpr::Number(Number::Int(0))]))],
+            vec![assign(
+                "y",
+                call("g", vec![DataExpr::Number(Number::Int(0))]),
+            )],
         );
         let prog = Program {
             statements: vec![TopLevel::Function(g), TopLevel::Function(h)],


### PR DESCRIPTION
**Restores `main`'s CI.** #42 was merged with a failing `cargo fmt --check` (both `Check (ubuntu)` and `Check (macos)` were red), so `main`'s `Check` is currently broken. `effect.rs` had two unformatted spots — a wide match arm and a wrapped test argument — that `rustfmt` rewraps.

This is **`cargo fmt` only — no code change**. Verified locally: `cargo fmt --check`, `clippy -D warnings`, and the jtv-core tests are all green; the diff is 6/4 lines in `effect.rs` alone.

My miss: I ran clippy + tests before pushing #42 but not `cargo fmt --check`. I've added `cargo fmt --all -- --check` to my pre-push routine for Rust changes so this doesn't recur.

With this merged, `main` is green again and the (b) implementation (inference + call composition) stands. Next: the **Lean mechanisation** of the function-effect lattice, then **number-systems**.

https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742)_