### PR TITLE
chore(rename): Julia the Viper → JtV (repo slug + full prose rebrand)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,7 +17,7 @@
 *.v text eol=lf
 *.zig text eol=lf
 
-# Julia-the-Viper source + conformance corpus. These are parsed byte-exactly by
+# JtV source + conformance corpus. These are parsed byte-exactly by
 # the test suite, so pin LF: the cross-platform CI matrix must read identical
 # bytes on a Windows checkout (otherwise CRLF would change parser/whitespace
 # behaviour and fail conformance tests only on Windows).

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# GitLab CI/CD Configuration for Julia the Viper
+# GitLab CI/CD Configuration for JtV
 
 variables:
   CARGO_HOME: "${CI_PROJECT_DIR}/.cargo"

--- a/.machine_readable/6a2/AGENTIC.a2ml
+++ b/.machine_readable/6a2/AGENTIC.a2ml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
-# AGENTIC.a2ml — AI agent constraints and capabilities for julia-the-viper
+# AGENTIC.a2ml — AI agent constraints and capabilities for jtv
 [metadata]
 version = "0.2.0"
 last-updated = "2026-04-19"

--- a/.machine_readable/6a2/ECOSYSTEM.a2ml
+++ b/.machine_readable/6a2/ECOSYSTEM.a2ml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
-# ECOSYSTEM.a2ml — Julia The Viper ecosystem position
+# ECOSYSTEM.a2ml — JtV ecosystem position
 [metadata]
 version = "1.1"
 last-updated = "2026-04-19"
 
 [project]
-name = "Julia The Viper"
+name = "JtV"
 purpose = "Harvard-architecture programming language with grammatical Control/Data separation; universal extender for injection-resistant retrofits"
 role = "Programming language — user-facing runtime substrate"
 

--- a/.machine_readable/6a2/META.a2ml
+++ b/.machine_readable/6a2/META.a2ml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
-# META.a2ml — Julia The Viper meta-level information
+# META.a2ml — JtV meta-level information
 [metadata]
 version = "0.3.0"
 last-updated = "2026-06-02"

--- a/.machine_readable/6a2/NEUROSYM.a2ml
+++ b/.machine_readable/6a2/NEUROSYM.a2ml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
-# NEUROSYM.a2ml — Neurosymbolic integration metadata for julia-the-viper
+# NEUROSYM.a2ml — Neurosymbolic integration metadata for jtv
 [metadata]
 version = "0.2.0"
 last-updated = "2026-04-19"

--- a/.machine_readable/6a2/PLAYBOOK.a2ml
+++ b/.machine_readable/6a2/PLAYBOOK.a2ml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
-# PLAYBOOK.a2ml — Julia The Viper operational runbook
+# PLAYBOOK.a2ml — JtV operational runbook
 [metadata]
 version = "0.2.0"
 last-updated = "2026-04-19"

--- a/.machine_readable/6a2/STATE.a2ml
+++ b/.machine_readable/6a2/STATE.a2ml
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
-# STATE.a2ml — Julia The Viper project state
+# STATE.a2ml — JtV project state
 [metadata]
-project = "julia-the-viper"
+project = "jtv"
 version = "0.0.1"
 last-updated = "2026-06-18"
 status = "active"
 session = "2026-06-18 — Echo arc completed + number systems stratified. (b) Echo+Epistemic first-class DONE (proof side, ADR-0009): JtvEcho.lean SECTION 5 = Epistemic lattice + Echo×Epistemic product FunctionEffect lattice + comm/assoc/idem composition laws (matching the already-merged echo.rs/epistemic.rs/effect.rs). Number systems STRATIFIED (ADR-0007 D6 realized as ADR-0010): JtvEcho.lean SECTION 6 3-level NumAlgebra tower 1:1 with the Echo lattice (hex/binary=ℤ-encodings collapse to int's tier; float=approxGroup→Neutral); echo.rs carrier-aware classification (CarrierEnv; reversible += graded shape⊔carrier; default-carrier=Int sound) + effect.rs param-seeded env; number.rs runtime-value bridge Value::reversal_echo. PR #44 + #45 (bridge+ADR-0010) merged; float-LOCALS soundness gate also LANDED (typechecker.rs check_echo_admissible{,_with_residue} seed CarrierEnv from the inferred env self.env → reverse{} over a float local correctly rejected, float routes to reversible{}->tok). lake + cargo green (127 lib tests, 0 sorry/unwrap). NEXT rung: value-level semantics beyond τ=int (gap-005)"
 
 [project-context]
-name = "Julia The Viper"
+name = "JtV"
 purpose = """Harvard-architecture programming language with grammatical separation
 of Control (Turing-complete) and Data (total, addition-only). Universal extender
 for injection-resistant retrofits. v2 adds reversibility via reverse blocks.

--- a/.machine_readable/anchors/ANCHOR.a2ml
+++ b/.machine_readable/anchors/ANCHOR.a2ml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
-# ANCHOR.a2ml - authoritative anchor for julia-the-viper
+# ANCHOR.a2ml - authoritative anchor for jtv
 
 [metadata]
 version = "1.0.0"
@@ -9,16 +9,16 @@ last-updated = "2026-06-13"
 
 [anchor]
 schema = "hyperpolymath.anchor/1"
-repo = "hyperpolymath/julia-the-viper"
+repo = "hyperpolymath/jtv"
 authority = "upstream-canonical"
 purpose = [
-  "Define canonical semantics and policy boundaries for julia-the-viper.",
+  "Define canonical semantics and policy boundaries for jtv.",
   "Declare what downstream/satellite repos can extend but not redefine.",
   "Provide a stable golden path and invariant contract for release readiness.",
 ]
 
 [identity]
-project = "Julia the Viper"
+project = "JtV"
 kind = "language"
 one-sentence = "Harvard-architecture, addition-only language that makes code injection grammatically impossible; v2 adds reverse-addition reversibility with Echo loss-lineage."
 domain = "programming-languages / security / formal-methods"

--- a/.machine_readable/bot_directives/README.adoc
+++ b/.machine_readable/bot_directives/README.adoc
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell
-= Bot directives — julia-the-viper
+= Bot directives — jtv
 :toc:
 
 == Purpose
 
 Per-repo directives for automated agents operating on
-`hyperpolymath/julia-the-viper`: what is safe, what is forbidden, and
+`hyperpolymath/jtv`: what is safe, what is forbidden, and
 which findings are already adjudicated, so automated runs do not
 relitigate settled decisions or touch protected surfaces.
 

--- a/.machine_readable/bot_directives/git-private-farm.a2ml
+++ b/.machine_readable/bot_directives/git-private-farm.a2ml
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
 # git-private-farm.a2ml — .git-private-farm propagation directives for
-# julia-the-viper. Per the estate bot_directives standard.
+# jtv. Per the estate bot_directives standard.
 
 [metadata]
-repo = "julia-the-viper"
+repo = "jtv"
 last-updated = "2026-06-14"
 owner = "hyperpolymath"
 
 [propagation]
 enabled = false
-# instant-sync.yml is absent in julia-the-viper as of 2026-06-14.
+# instant-sync.yml is absent in jtv as of 2026-06-14.
 # The keys below record the estate contract that applies if/when it is added.
 workflow = ".github/workflows/instant-sync.yml"
 target = "hyperpolymath/.git-private-farm"
@@ -21,4 +21,4 @@ presence-gated = false
 items = ["secrets", "unmerged branches", "work-in-progress"]
 
 [on-token-rotation]
-command = "gh secret set FARM_DISPATCH_TOKEN --repo hyperpolymath/julia-the-viper"
+command = "gh secret set FARM_DISPATCH_TOKEN --repo hyperpolymath/jtv"

--- a/.machine_readable/bot_directives/gitbot-fleet.a2ml
+++ b/.machine_readable/bot_directives/gitbot-fleet.a2ml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
-# gitbot-fleet.a2ml — gitbot fleet directives for julia-the-viper.
+# gitbot-fleet.a2ml — gitbot fleet directives for jtv.
 # Per the estate bot_directives standard (estate-standardization wave).
 
 [metadata]
-repo = "julia-the-viper"
+repo = "jtv"
 last-updated = "2026-06-14"
 owner = "hyperpolymath"
 

--- a/.machine_readable/bot_directives/hypatia.a2ml
+++ b/.machine_readable/bot_directives/hypatia.a2ml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
-# hypatia.a2ml — Hypatia scanner directives for julia-the-viper.
+# hypatia.a2ml — Hypatia scanner directives for jtv.
 # Per the estate bot_directives standard (estate-standardization wave).
 
 [metadata]
-repo = "julia-the-viper"
+repo = "jtv"
 last-updated = "2026-06-15"
 owner = "hyperpolymath"
 

--- a/.machine_readable/contractiles/Adjustfile.a2ml
+++ b/.machine_readable/contractiles/Adjustfile.a2ml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Adjustfile — Accessibility & adaptation invariants for julia-the-viper.
+# Adjustfile — Accessibility & adaptation invariants for jtv.
 # Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # Migrated 2026-06-13 from .machine_readable/ADJUST.contractile (content preserved).
 # All ADJUST invariants are implicitly MUST invariants (tracked separately for visibility).

--- a/.machine_readable/contractiles/Bustfile.a2ml
+++ b/.machine_readable/contractiles/Bustfile.a2ml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Bustfile — Adversarial / injection-stress contract for julia-the-viper.
+# Bustfile — Adversarial / injection-stress contract for jtv.
 # Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # New 2026-06-13. bust = active "safe-hacking" attempts (outrageous-attack catchment),
 # the natural home for JtV's killer property: injection must be grammatically rejected.

--- a/.machine_readable/contractiles/Dustfile.a2ml
+++ b/.machine_readable/contractiles/Dustfile.a2ml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Dustfile — Deprecation & recovery semantics for julia-the-viper.
+# Dustfile — Deprecation & recovery semantics for jtv.
 # Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # New 2026-06-13 (jtv referenced DUST in prose but had no Dustfile).
 

--- a/.machine_readable/contractiles/Intentfile.a2ml
+++ b/.machine_readable/contractiles/Intentfile.a2ml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Intentfile — Purpose, anti-purpose, and roadmap intents for julia-the-viper.
+# Intentfile — Purpose, anti-purpose, and roadmap intents for jtv.
 # Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # Migrated 2026-06-13 from .machine_readable/INTENT.contractile (content preserved).
 # (intend absorbs the deprecated `lust` wishes schema, 2026-04-18.)

--- a/.machine_readable/contractiles/Mustfile.a2ml
+++ b/.machine_readable/contractiles/Mustfile.a2ml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MPL-2.0
-# Mustfile — Physical-state invariants for julia-the-viper. Hard requirements.
+# Mustfile — Physical-state invariants for jtv. Hard requirements.
 # Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # Migrated 2026-06-13 from .machine_readable/MUST.contractile (content preserved).
 
 @abstract:
-What MUST be true about julia-the-viper. Violating a MUST is always a bug;
+What MUST be true about jtv. Violating a MUST is always a bug;
 K9 validators + CI gate every PR. The Harvard thesis + addition-only +
 proof invariants are load-bearing.
 @end

--- a/.machine_readable/contractiles/Trustfile.a2ml
+++ b/.machine_readable/contractiles/Trustfile.a2ml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Trustfile — Agent trust contract for julia-the-viper.
+# Trustfile — Agent trust contract for jtv.
 # Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # Migrated 2026-06-13 from .machine_readable/TRUST.contractile (content preserved).
 

--- a/.machine_readable/self-validating/README.adoc
+++ b/.machine_readable/self-validating/README.adoc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell
-= Self-validating K9 templates — julia-the-viper
+= Self-validating K9 templates — jtv
 :toc:
 
 Estate K9 self-validation templates (k9-validate-action format: `K9!`
@@ -17,6 +17,6 @@ service. Validated by the `Validate K9 contracts` job in
 NOTE: the contractile k9-components under `.machine_readable/contractiles/`
 (when present in the standards `{family}/` trident form) are a DIFFERENT
 artifact — Nickel runner-companions, not `K9!`-magic service files — and
-are out of scope for that validator. julia-the-viper uses the estate-wave
+are out of scope for that validator. jtv uses the estate-wave
 *flat* contractile layout, so its `contractiles/` holds only `*file.a2ml`
 declarations (+ a `Justfile`), no `.k9.ncl`.

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -2,23 +2,23 @@
 # https://securitytxt.org/
 
 Contact: mailto:security@julia-viper.dev
-Contact: https://github.com/hyperpolymath/julia-the-viper/security/advisories/new
+Contact: https://github.com/hyperpolymath/jtv/security/advisories/new
 Expires: 2027-01-31T23:59:59.000Z
-Encryption: https://github.com/hyperpolymath/julia-the-viper/blob/main/.well-known/pgp-key.txt
+Encryption: https://github.com/hyperpolymath/jtv/blob/main/.well-known/pgp-key.txt
 Preferred-Languages: en
 Canonical: https://julia-viper.dev/.well-known/security.txt
-Policy: https://github.com/hyperpolymath/julia-the-viper/blob/main/SECURITY.md
-Acknowledgments: https://github.com/hyperpolymath/julia-the-viper/blob/main/SECURITY.md#security-hall-of-fame
+Policy: https://github.com/hyperpolymath/jtv/blob/main/SECURITY.md
+Acknowledgments: https://github.com/hyperpolymath/jtv/blob/main/SECURITY.md#security-hall-of-fame
 
 # Security Guarantees
-# Julia the Viper provides architectural security guarantees:
+# JtV provides architectural security guarantees:
 # - Code injection is grammatically impossible (Harvard Architecture)
 # - No integer overflow in Data Language (checked operations)
 # - No reentrancy attacks (atomic state updates)
 # - Guaranteed termination for pure functions (totality checking)
 #
 # For vulnerability reporting guidelines, see:
-# https://github.com/hyperpolymath/julia-the-viper/blob/main/SECURITY.md
+# https://github.com/hyperpolymath/jtv/blob/main/SECURITY.md
 #
 # Response timeline:
 # - Initial response: 48 hours

--- a/0-AI-MANIFEST.a2ml
+++ b/0-AI-MANIFEST.a2ml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
-# Julia the Viper - AI Manifest (Gateway File)
+# JtV - AI Manifest (Gateway File)
 #
 # THIS FILE MUST BE READ FIRST BY ALL AI AGENTS.
 #
-# Julia the Viper is a Harvard Architecture programming language that
+# JtV is a Harvard Architecture programming language that
 # grammatically separates Control Language (Turing-complete) from
 # Data Language (Total/provably halting, addition-only). This makes
 # code injection structurally impossible at the grammar level.
@@ -62,7 +62,7 @@
 
 ### Editor Support
 
-- `editors/julia-the-viper.tmLanguage.json`    - TextMate grammar (standalone)
+- `editors/jtv.tmLanguage.json`    - TextMate grammar (standalone)
 - `editors/vscode/syntaxes/jtv.tmLanguage.json` - VS Code extension grammar
 - `editors/vscode/snippets/jtv.json`            - VS Code snippets
 - `editors/vscode/package.json`                 - VS Code extension manifest
@@ -125,7 +125,7 @@
 - `spec/README.adoc` — @taxonomy: spec/index
 - `verification/README.adoc` — @taxonomy: verification/index
 - `crates/jtv-core/src/parser.rs` — @taxonomy: compiler/parser
-- `editors/julia-the-viper.tmLanguage.json` — @taxonomy: editors/textmate-grammar
+- `editors/jtv.tmLanguage.json` — @taxonomy: editors/textmate-grammar
 
 ### New RSR Standard Directories
 

--- a/ALIGNMENT-AFFINESCRIPT.adoc
+++ b/ALIGNMENT-AFFINESCRIPT.adoc
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
-= Julia the Viper → AffineScript Alignment Plan
+= JtV → AffineScript Alignment Plan
 :toc:
 :toclevels: 3
 :revdate: 2026-06-02
 
-Bring *Julia the Viper* (JtV) from its current position to the same level of
+Bring *JtV* from its current position to the same level of
 *maturity and governance discipline* that `hyperpolymath/affinescript` has
 reached — *starting with proofs*. This document is the master plan; it is
 deliberately conservative and honest, in the spirit of `ROADMAP.adoc`.

--- a/ANCHOR.scope-arrest.2026-01-01.Jewell.scm
+++ b/ANCHOR.scope-arrest.2026-01-01.Jewell.scm
@@ -1,18 +1,18 @@
 ;; SPDX-FileCopyrightText: 2026 Hyperpolymath
 ;; SPDX-License-Identifier: MPL-2.0
 ;;
-;; ANCHOR.scope-arrest.2026-01-01.Jewell.scm  (julia-the-viper)
+;; ANCHOR.scope-arrest.2026-01-01.Jewell.scm  (jtv)
 ;;
 ;; Purpose: Freeze v1 as runnable core; prevent v2/spec ambition from destabilising v1.
 
 (define anchor
   '((schema . "hyperpolymath.anchor/1")
-    (repo . "hyperpolymath/julia-the-viper")
+    (repo . "hyperpolymath/jtv")
     (date . "2026-01-01")
     (authority . "repo-superintendent")
     (purpose . ("Freeze v1 as runnable core; prevent v2/spec ambition from destabilising v1."))
     (identity
-      . ((project . "Julia the Viper (JtV)")
+      . ((project . "JtV")
          (kind . "security language")
          (domain . "grammar-enforced separation (control vs data)")
          (one-sentence . "A Harvard-architecture language where control and data are syntactically separated to reduce injection and hidden-control channels.")))

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 = Changelog
 
-All notable changes to Julia the Viper will be documented in this file.
+All notable changes to JtV will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -123,6 +123,6 @@ None yet. See SECURITY.md for reporting vulnerabilities.
 
 ---
 
-For older versions, see [GitHub Releases](https://github.com/Hyperpolymath/julia-the-viper/releases).
+For older versions, see [GitHub Releases](https://github.com/Hyperpolymath/jtv/releases).
 
 Last updated: 2025-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
 
 # Changelog
 
-All notable changes to `julia-the-viper` will be documented in this file.
+All notable changes to `jtv` will be documented in this file.
 
 This file is generated from conventional commits by the
 [`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# Julia the Viper (JtV)
+# JtV
 
 ## Project Overview
 
-**Julia the Viper** is a Harvard Architecture programming language designed as a "universal extender" to fix code injection vulnerabilities in legacy systems (Python/PHP/JS). The name honors mathematician **Julia Robinson** while making a playful pun on "adder" (snake + addition).
+**JtV** is a Harvard Architecture programming language designed as a "universal extender" to fix code injection vulnerabilities in legacy systems (Python/PHP/JS). The original name — *Julia the Viper* — honored mathematician **Julia Robinson** while punning on "adder" (snake + addition); it is now just **JtV** so the "Julia" is no longer mistaken for the Julia language (see *Etymology & Humor* below).
 
 ### The Core Insight
 
@@ -13,7 +13,7 @@ JtV grammatically separates **Control Language** (Turing-complete, imperative) f
 This repository currently contains the conceptual foundation:
 
 ```
-julia-the-viper/
+jtv/
 ├── README.md           # Project tagline: "It's basically the same thing as an adder"
 ├── julia-viper         # Pseudocode showing the humorous starting point
 ├── LICENSE             # GPL-3.0
@@ -141,9 +141,11 @@ If you see references to:
 
 ## Etymology & Humor
 
-The project embraces wordplay:
+**JtV was formerly named *Julia the Viper*.** It now goes by **JtV** so the
+"Julia" in the title is no longer mistaken — by people and bots alike — for the
+Julia programming language. The wordplay behind the original name lives on:
 
-- **Julia Robinson**: Mathematician who solved Hilbert's 10th problem
+- **Julia Robinson**: Mathematician who solved Hilbert's 10th problem (the "Julia")
 - **Viper**: A snake (like "adder", which is both a snake and a calculator)
 - **"It's basically the same thing as an adder"**: Humble origin story
 - **Addition-only**: Seems limited, actually universal

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -132,7 +132,7 @@ For answers to common questions about this code of conduct, see the FAQ at
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
 
-## Julia the Viper Specific Addendum
+## JtV Specific Addendum
 
 ### Technical Discourse
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,4 +1,4 @@
-= Contributing to Julia the Viper
+= Contributing to JtV
 :toc: left
 :toclevels: 3
 :icons: font
@@ -44,8 +44,8 @@ Be respectful, constructive, and professional. We're building something importan
 [source,bash]
 ----
 # Fork the repo
-git clone https://github.com/YOUR_USERNAME/julia-the-viper
-cd julia-the-viper
+git clone https://github.com/YOUR_USERNAME/jtv
+cd jtv
 
 # Install dependencies
 just install
@@ -108,7 +108,7 @@ just example 01_hello_addition
 
 [source]
 ----
-julia-the-viper/
+jtv/
 ├── packages/
 │   ├── jtzig/        # Core Rust implementation
 │   ├── jtv-analyzer/    # TypeScript code analyzer
@@ -364,7 +364,7 @@ See link:LICENSE.txt[LICENSE.txt] for details.
 
 == Trademark Policy
 
-The name "Julia the Viper" and the JtV logo are trademarks of the Julia the Viper project. When using these marks:
+The name "JtV" and the JtV logo are trademarks of the JtV project. When using these marks:
 
 * You may use them to refer to the project
 * You may use them in documentation and educational materials

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Julia the Viper - Workspace Root
+# JtV - Workspace Root
 
 [workspace]
 resolver = "2"
@@ -18,7 +18,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>"]
 license = "MPL-2.0"
-repository = "https://github.com/hyperpolymath/julia-the-viper"
+repository = "https://github.com/hyperpolymath/jtv"
 keywords = ["security", "formal-verification", "parser", "interpreter", "wasm"]
 categories = ["compilers", "parsing", "wasm"]
 

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,4 +1,4 @@
-# Julia the Viper: Development Roadmap & Technical Decisions
+# JtV: Development Roadmap & Technical Decisions
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 **Version:** 1.0
@@ -489,7 +489,7 @@ The Elm Architecture (TEA) / Model-View-Update (MVU) pattern. This provides:
 // package.json
 {
   "name": "jtv-vscode",
-  "displayName": "Julia the Viper",
+  "displayName": "JtV",
   "publisher": "jtv",
   "engines": { "vscode": "^1.85.0" },
   "categories": ["Programming Languages"],
@@ -601,7 +601,7 @@ ENTRYPOINT ["jtv"]
 ## 3. Directory Structure
 
 ```
-julia-the-viper/
+jtv/
 ├── crates/                      # Rust workspace
 │   ├── jtv-core/               # Parser, AST, types
 │   │   ├── src/

--- a/EXPLAINME.adoc
+++ b/EXPLAINME.adoc
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
-= Julia the Viper — EXPLAINME
+= JtV — EXPLAINME
 :toc: left
 :toclevels: 3
 

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -4,10 +4,10 @@
 # github: [Hyperpolymath]
 
 # Open Collective (future)
-# open_collective: julia-the-viper
+# open_collective: jtv
 
 # Patreon (if applicable)
-# patreon: julia-the-viper
+# patreon: jtv
 
 # Custom links
 custom:

--- a/GOVERNANCE.adoc
+++ b/GOVERNANCE.adoc
@@ -5,13 +5,13 @@
 
 == Overview
 
-Julia the Viper follows a meritocratic governance model based on the Tri-Perimeter Contribution Framework (TPCF). This document describes decision-making processes, roles, and responsibilities.
+JtV follows a meritocratic governance model based on the Tri-Perimeter Contribution Framework (TPCF). This document describes decision-making processes, roles, and responsibilities.
 
 == Current State
 
 [IMPORTANT]
 ====
-*Julia the Viper v0.1.0* is currently in *Perimeter 3 (Community Sandbox)* mode.
+*JtV v0.1.0* is currently in *Perimeter 3 (Community Sandbox)* mode.
 
 We are actively seeking founding maintainers and trusted contributors.
 ====
@@ -20,7 +20,7 @@ We are actively seeking founding maintainers and trusted contributors.
 
 === Three-Tiered Model
 
-Julia the Viper uses graduated trust perimeters to balance security with community participation:
+JtV uses graduated trust perimeters to balance security with community participation:
 
 [cols="1,2,2,2"]
 |===
@@ -413,7 +413,7 @@ Semantic versioning (SemVer 2.0.0):
 
 === Project Trademarks
 
-* "Julia the Viper" (name)
+* "JtV" (name)
 * JtV logo (design)
 * Project mascot (when created)
 

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Justfile - Julia the Viper build system
+# Justfile - JtV build system
 
 # Default: show all available commands
 import? "contractile.just"
@@ -239,7 +239,7 @@ assail:
 
 # Self-diagnostic — checks dependencies, permissions, paths, proofs. Taxonomy: REF
 doctor:
-    @echo "Running diagnostics for julia-the-viper..."
+    @echo "Running diagnostics for jtv..."
     @FAIL=0; \
     echo "=== Required Tools ==="; \
     command -v just >/dev/null 2>&1 && echo "  [OK] just" || { echo "  [FAIL] just not found"; FAIL=1; }; \
@@ -269,7 +269,7 @@ doctor:
 
 # Auto-repair common issues
 heal:
-    @echo "Attempting auto-repair for julia-the-viper..."
+    @echo "Attempting auto-repair for jtv..."
     @echo "Fixing permissions..."
     @find . -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
     @echo "Cleaning stale caches..."
@@ -278,7 +278,7 @@ heal:
 
 # Guided tour of key features
 tour:
-    @echo "=== julia-the-viper Tour ==="
+    @echo "=== jtv Tour ==="
     @echo ""
     @echo "1. Project structure:"
     @ls -la
@@ -293,12 +293,12 @@ tour:
 
 # Open feedback channel with diagnostic context
 help-me:
-    @echo "=== julia-the-viper Help ==="
+    @echo "=== jtv Help ==="
     @echo "Platform: $(uname -s) $(uname -m)"
     @echo "Shell: $SHELL"
     @echo ""
     @echo "To report an issue:"
-    @echo "  https://github.com/hyperpolymath/julia-the-viper/issues/new"
+    @echo "  https://github.com/hyperpolymath/jtv/issues/new"
     @echo ""
     @echo "Include the output of 'just doctor' in your report."
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@
 
 # Licensing
 
-Julia the Viper is **dual-licensed by artifact type**:
+JtV is **dual-licensed by artifact type**:
 
 | Artifact | License | SPDX |
 |----------|---------|------|

--- a/QUICKSTART-DEV.adoc
+++ b/QUICKSTART-DEV.adoc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Template: QUICKSTART-DEV.adoc — clone → build → test → PR
-// Replace julia-the-viper, {{BUILD_CMD}}, {{TEST_CMD}}, {{LANG_STACK}} with actuals
-= julia-the-viper — Quick Start for Developers
+// Replace jtv, {{BUILD_CMD}}, {{TEST_CMD}}, {{LANG_STACK}} with actuals
+= jtv — Quick Start for Developers
 :toc:
 :toclevels: 2
 
@@ -29,8 +29,8 @@ nix develop
 
 [source,bash]
 ----
-git clone https://github.com/hyperpolymath/julia-the-viper.git
-cd julia-the-viper
+git clone https://github.com/hyperpolymath/jtv.git
+cd jtv
 just setup-dev
 ----
 
@@ -52,7 +52,7 @@ just setup-dev
 
 [source]
 ----
-julia-the-viper/
+jtv/
 ├── src/                  # Source code
 ├── src/abi/              # Idris2 ABI definitions (if applicable)
 ├── ffi/zig/              # Zig FFI bridge (if applicable)
@@ -107,5 +107,5 @@ Or read `0-AI-MANIFEST.a2ml` and `.claude/CLAUDE.md` directly.
 == Get Help
 
 * **Architecture**: link:EXPLAINME.adoc[EXPLAINME.adoc]
-* **Wiki**: https://github.com/hyperpolymath/julia-the-viper/wiki
+* **Wiki**: https://github.com/hyperpolymath/jtv/wiki
 * **Report issue**: `just help-me`

--- a/QUICKSTART-MAINTAINER.adoc
+++ b/QUICKSTART-MAINTAINER.adoc
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Template: QUICKSTART-MAINTAINER.adoc — packaging, deploying, and maintaining
-// Replace julia-the-viper, {{PACKAGE_NAME}}, {{DEPS}} with actuals
-= julia-the-viper — Quick Start for Platform Maintainers
+// Replace jtv, {{PACKAGE_NAME}}, {{DEPS}} with actuals
+= jtv — Quick Start for Platform Maintainers
 :toc:
 :toclevels: 2
 
 == Overview
 
-This guide covers packaging, deploying, and maintaining julia-the-viper for
+This guide covers packaging, deploying, and maintaining jtv for
 distribution on your platform.
 
 == Runtime Dependencies
@@ -18,8 +18,8 @@ distribution on your platform.
 
 [source,bash]
 ----
-git clone https://github.com/hyperpolymath/julia-the-viper.git
-cd julia-the-viper
+git clone https://github.com/hyperpolymath/jtv.git
+cd jtv
 just build-release
 ----
 
@@ -46,7 +46,7 @@ nix build
 [source,bash]
 ----
 just stapeln-export    # Generates Containerfile
-podman build -t julia-the-viper .
+podman build -t jtv .
 ----
 
 === Manual Package
@@ -125,5 +125,5 @@ Each instance has isolated config, data, and logs.
 
 == Reporting Issues
 
-* Upstream: https://github.com/hyperpolymath/julia-the-viper/issues
+* Upstream: https://github.com/hyperpolymath/jtv/issues
 * With diagnostic: `just help-me` (pre-fills context)

--- a/QUICKSTART-USER.adoc
+++ b/QUICKSTART-USER.adoc
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Template: QUICKSTART-USER.adoc — 5-minute path to working software
-// Replace julia-the-viper, Julia The Viper — See README.adoc for details., just run, Julia The Viper started successfully. with actuals
-= julia-the-viper — Quick Start for Users
+// Replace jtv, JtV — See README.adoc for details., just run, JtV started successfully. with actuals
+= jtv — Quick Start for Users
 :toc:
 :toclevels: 2
 
-== What is julia-the-viper?
+== What is jtv?
 
-Julia The Viper — See README.adoc for details.
+JtV — See README.adoc for details.
 
 == Prerequisites
 
@@ -37,8 +37,8 @@ Before you begin, ensure you have:
 [source,bash]
 ----
 # Clone and set up
-git clone https://github.com/hyperpolymath/julia-the-viper.git
-cd julia-the-viper
+git clone https://github.com/hyperpolymath/jtv.git
+cd jtv
 just setup
 ----
 
@@ -61,7 +61,7 @@ just stapeln-run
 
 [source,bash]
 ----
-just install --portable --prefix=./julia-the-viper-portable
+just install --portable --prefix=./jtv-portable
 ----
 
 == First Run
@@ -75,7 +75,7 @@ Expected output:
 
 [source]
 ----
-Julia The Viper started successfully.
+JtV started successfully.
 ----
 
 == Self-Diagnostic
@@ -102,7 +102,7 @@ just heal
 * **In-app**: `just run --help`
 * **Guided tour**: `just tour`
 * **Report a problem**: `just help-me` (pre-fills diagnostic context)
-* **Wiki**: https://github.com/hyperpolymath/julia-the-viper/wiki
+* **Wiki**: https://github.com/hyperpolymath/jtv/wiki
 
 == Uninstall
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 
-= Julia the Viper (JtV)
+= JtV
 
 image:https://img.shields.io/badge/OpenSSF-Best_Practices-green?logo=opensourcesecurity[OpenSSF Best Practices,link="https://www.bestpractices.dev/en/projects/new?repo_url=https://github.com/hyperpolymath/jtv"]
 image:https://img.shields.io/badge/Code-MPL--2.0-blue.svg[Code: MPL-2.0,link="LICENSE"]
@@ -11,6 +11,13 @@ image:https://api.thegreenwebfoundation.org/greencheckimage/github.com[Green Web
 A Harvard-architecture programming language that makes code injection *grammatically impossible* — not as a runtime check, but as a structural guarantee.
 
 Named after mathematician **Julia Robinson** (Hilbert's 10th problem) with a playful nod to "adder": a snake, and the fundamental operation the language builds everything from.
+
+[NOTE]
+====
+*Formerly "Julia the Viper".* The project now goes by *JtV* so the "Julia" in the
+name is no longer mistaken — by people and bots alike — for the Julia programming
+language. The Julia-Robinson honour and the "adder" pun carry over to the short name.
+====
 
 ---
 
@@ -242,7 +249,7 @@ just build-wasm   # requires wasm-pack
 
 [source]
 ----
-julia-the-viper/
+jtv/
 ├── crates/
 │   ├── jtv-core/         Rust interpreter + type system + reversibility
 │   ├── jtv-cli/          REPL and command-line interface

--- a/ROADMAP.adoc
+++ b/ROADMAP.adoc
@@ -1,4 +1,4 @@
-= Julia the Viper — Roadmap
+= JtV — Roadmap
 
 This roadmap describes the *actual development trajectory* of JtV as a research language.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ We release security updates for the following versions:
 
 ### Security Guarantees
 
-Julia the Viper provides the following **architectural security guarantees**:
+JtV provides the following **architectural security guarantees**:
 
 #### 1. Code Injection is Grammatically Impossible
 

--- a/SESSION-RESUME-2026-01-31.md
+++ b/SESSION-RESUME-2026-01-31.md
@@ -1,4 +1,4 @@
-# Session Resume - Julia the Viper (2026-01-31)
+# Session Resume - JtV (2026-01-31)
 
 ## What Was Done Before the Crash
 
@@ -55,7 +55,7 @@ Created complete PWA infrastructure in `web/`:
   - Service worker registration
 
 - `manifest.json` - PWA manifest with:
-  - App name: "Julia the Viper Playground"
+  - App name: "JtV Playground"
   - Theme colors (purple gradient)
   - Icons configuration (192x192, 512x512)
   - Standalone display mode
@@ -112,7 +112,7 @@ Created complete PWA infrastructure in `web/`:
 
 ```bash
 # Build WASM
-cd ~/Documents/hyperpolymath-repos/julia-the-viper
+cd ~/Documents/hyperpolymath-repos/jtv
 just build-wasm
 
 # Serve PWA (production)
@@ -125,8 +125,8 @@ just dev-pwa
 Visit: http://localhost:8000/
 
 ### Repository Location
-- **Canonical:** `~/Documents/hyperpolymath-repos/julia-the-viper/`
-- **Physical:** `/var$REPOS_DIR/julia-the-viper/` (Eclipse drive)
+- **Canonical:** `~/Documents/hyperpolymath-repos/jtv/`
+- **Physical:** `/var$REPOS_DIR/jtv/` (Eclipse drive)
 - **Note:** Always use the symlink path for operations
 
 ## Key Files Modified

--- a/STATUS.adoc
+++ b/STATUS.adoc
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // SPDX-FileCopyrightText: 2025-2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
-= Julia the Viper — Status
+= JtV — Status
 
 _Version is tracked in `Cargo.toml` and `CHANGELOG.adoc`._
 
 *Stage*: Alpha (active research)
 *Assessment*: B- (solid core, proofs now compiling, verification chain still incomplete)
 
-Julia the Viper is an experimental language with a fully implemented Rust core,
+JtV is an experimental language with a fully implemented Rust core,
 a substantial test suite, and formally verified proof artefacts that now compile
 cleanly. The verification chain from proofs to executable is still incomplete.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,4 +1,4 @@
-# Julia the Viper - Status
+# JtV - Status
 
 **⚠️ THIS FILE IS DEPRECATED**
 
@@ -12,7 +12,7 @@ For current status information, see:
 
 **Current Status (2026-02-07):** ✅ **100% Complete - Production Ready**
 
-Julia the Viper is now production-ready with:
+JtV is now production-ready with:
 - ✅ Complete toolchain (parser, type checker, interpreter, formatter)
 - ✅ WASM backend (591 LOC, fully functional)
 - ✅ LSP server (tower-lsp integration)

--- a/TEST-NEEDS.md
+++ b/TEST-NEEDS.md
@@ -1,4 +1,4 @@
-# TEST-NEEDS.md — julia-the-viper
+# TEST-NEEDS.md — jtv
 
 <!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
 

--- a/TOPOLOGY.md
+++ b/TOPOLOGY.md
@@ -1,16 +1,16 @@
 <!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
 <!-- Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk> -->
 
-# TOPOLOGY.md — julia-the-viper
+# TOPOLOGY.md — jtv
 
 ## Purpose
 
-Julia the Viper: Harvard Architecture language for security-critical applications. Named after mathematician Julia Robinson and playful "adder" (snake + addition), JtV makes code injection grammatically impossible by separating computation into two distinct channels: Control Language (Turing-complete) and Data Language (total, addition-only).
+JtV: Harvard Architecture language for security-critical applications. Named after mathematician Julia Robinson and playful "adder" (snake + addition), JtV makes code injection grammatically impossible by separating computation into two distinct channels: Control Language (Turing-complete) and Data Language (total, addition-only).
 
 ## Module Map
 
 ```
-julia-the-viper/
+jtv/
 ├── src/
 │   ├── control_language/      # Turing-complete control channel
 │   ├── data_language/         # Provably-halting data channel

--- a/TPCF.md
+++ b/TPCF.md
@@ -1,6 +1,6 @@
 # Tri-Perimeter Contribution Framework (TPCF)
 
-Julia the Viper implements the TPCF security model with three graduated trust perimeters.
+JtV implements the TPCF security model with three graduated trust perimeters.
 
 ## Overview
 
@@ -12,7 +12,7 @@ TPCF separates contribution surfaces by trust level:
 
 ## Current Configuration
 
-**Julia the Viper v0.1.0**: **Perimeter 3 (Community Sandbox)**
+**JtV v0.1.0**: **Perimeter 3 (Community Sandbox)**
 
 We are actively seeking founding maintainers and trusted contributors.
 

--- a/academic/BIBLIOGRAPHY.md
+++ b/academic/BIBLIOGRAPHY.md
@@ -1,4 +1,4 @@
-# Comprehensive Bibliography for Julia the Viper Academic Documentation
+# Comprehensive Bibliography for JtV Academic Documentation
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 
@@ -358,10 +358,10 @@ When citing JtV academic materials:
 
 ```bibtex
 @misc{jtv2025,
-  title = {Julia the Viper: A Harvard Architecture Language for Grammatically Enforced Code Injection Immunity},
+  title = {JtV: A Harvard Architecture Language for Grammatically Enforced Code Injection Immunity},
   author = {JtV Research Team},
   year = {2025},
-  howpublished = {\url{https://github.com/hyperpolymath/julia-the-viper}},
+  howpublished = {\url{https://github.com/hyperpolymath/jtv}},
   note = {Version 1.0}
 }
 ```

--- a/academic/README.md
+++ b/academic/README.md
@@ -1,8 +1,8 @@
-# Julia the Viper: Academic Documentation
+# JtV: Academic Documentation
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 
-This directory contains comprehensive academic documentation for Julia the Viper (JtV), including formal proofs, white papers, and theoretical foundations.
+This directory contains comprehensive academic documentation for JtV, including formal proofs, white papers, and theoretical foundations.
 
 ---
 
@@ -140,11 +140,11 @@ lake build
 
 ```bibtex
 @misc{jtv2025,
-  title = {Julia the Viper: A Harvard Architecture Language for
+  title = {JtV: A Harvard Architecture Language for
            Grammatically Enforced Code Injection Immunity},
   author = {JtV Research Team},
   year = {2025},
-  howpublished = {\url{https://github.com/hyperpolymath/julia-the-viper}},
+  howpublished = {\url{https://github.com/hyperpolymath/jtv}},
   note = {Version 1.0}
 }
 ```

--- a/academic/papers/WHITE_PAPER.md
+++ b/academic/papers/WHITE_PAPER.md
@@ -1,4 +1,4 @@
-# Julia the Viper: A Harvard Architecture Language for Grammatically Enforced Code Injection Immunity
+# JtV: A Harvard Architecture Language for Grammatically Enforced Code Injection Immunity
 
 **Authors:** The JtV Research Team
 **Version:** 1.0 (Draft)
@@ -9,7 +9,7 @@
 
 ## Abstract
 
-We present **Julia the Viper (JtV)**, a programming language that achieves code injection immunity through grammatical separation rather than runtime detection. By implementing a strict Harvard Architecture at the language level—separating a Turing-complete Control Language from a Total (provably halting) Data Language—JtV makes code injection attacks syntactically impossible. This paper formalizes the theoretical foundations, proves key security properties, and demonstrates practical applicability for retrofitting legacy systems vulnerable to injection attacks.
+We present **JtV**, a programming language that achieves code injection immunity through grammatical separation rather than runtime detection. By implementing a strict Harvard Architecture at the language level—separating a Turing-complete Control Language from a Total (provably halting) Data Language—JtV makes code injection attacks syntactically impossible. This paper formalizes the theoretical foundations, proves key security properties, and demonstrates practical applicability for retrofitting legacy systems vulnerable to injection attacks.
 
 **Keywords:** Code injection, Harvard Architecture, Total languages, Formal verification, Language-based security, Provable security
 
@@ -90,7 +90,7 @@ JtV extends this tradition by making security a grammatical rather than just typ
 
 ---
 
-## 3. The Julia the Viper Language
+## 3. The JtV Language
 
 ### 3.1 Syntax Overview
 
@@ -521,7 +521,7 @@ JtV uniquely combines:
 
 ## 12. Conclusion
 
-Julia the Viper demonstrates that code injection can be eliminated through language design rather than defensive programming. By enforcing Harvard Architecture at the grammar level, JtV achieves:
+JtV demonstrates that code injection can be eliminated through language design rather than defensive programming. By enforcing Harvard Architecture at the grammar level, JtV achieves:
 
 1. **Provable Security:** Code injection is grammatically impossible
 2. **Preserved Expressiveness:** Turing-complete for real applications

--- a/academic/proofs/ALGEBRAIC_STRUCTURES.md
+++ b/academic/proofs/ALGEBRAIC_STRUCTURES.md
@@ -1,4 +1,4 @@
-# Algebraic Structures in Julia the Viper
+# Algebraic Structures in JtV
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/academic/proofs/COMPUTATIONAL_THEORY.md
+++ b/academic/proofs/COMPUTATIONAL_THEORY.md
@@ -1,4 +1,4 @@
-# Computational Theory of Julia the Viper
+# Computational Theory of JtV
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/academic/proofs/MATHEMATICAL_FOUNDATIONS.md
+++ b/academic/proofs/MATHEMATICAL_FOUNDATIONS.md
@@ -1,8 +1,8 @@
-# Mathematical Foundations of Julia the Viper
+# Mathematical Foundations of JtV
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 
-This document establishes the rigorous mathematical foundations underlying the Julia the Viper programming language, drawing from set theory, category theory, domain theory, and lambda calculus.
+This document establishes the rigorous mathematical foundations underlying the JtV programming language, drawing from set theory, category theory, domain theory, and lambda calculus.
 
 ---
 

--- a/academic/proofs/QUANTUM_REVERSIBILITY.md
+++ b/academic/proofs/QUANTUM_REVERSIBILITY.md
@@ -1,4 +1,4 @@
-# Quantum Computing and Reversible Computation Theory for Julia the Viper
+# Quantum Computing and Reversible Computation Theory for JtV
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/academic/proofs/SECURITY_PROOFS.md
+++ b/academic/proofs/SECURITY_PROOFS.md
@@ -1,4 +1,4 @@
-# Security Proofs for Julia the Viper: A Formal Analysis
+# Security Proofs for JtV: A Formal Analysis
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/academic/proofs/STATISTICS_PROBABILITY.md
+++ b/academic/proofs/STATISTICS_PROBABILITY.md
@@ -1,4 +1,4 @@
-# Statistics and Probability Foundations for Julia the Viper
+# Statistics and Probability Foundations for JtV
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/academic/proofs/TYPE_THEORY.md
+++ b/academic/proofs/TYPE_THEORY.md
@@ -1,4 +1,4 @@
-# Type Theory of Julia the Viper: A Complete Formalization
+# Type Theory of JtV: A Complete Formalization
 
 **SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/contractiles/intend/Intentfile.a2ml
+++ b/contractiles/intend/Intentfile.a2ml
@@ -3,12 +3,12 @@
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath)
 
 @abstract:
-Declared intent and purpose for Julia The Viper.
+Declared intent and purpose for JtV.
 @end
 
 ## Purpose
 
-Julia The Viper — *Harvard Architecture Language for Security-Critical Applications*
+JtV — *Harvard Architecture Language for Security-Critical Applications*
 
 ## Anti-Purpose
 

--- a/contractiles/must/Mustfile.a2ml
+++ b/contractiles/must/Mustfile.a2ml
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath)
 
 @abstract:
-Physical State contract for Julia The Viper. Baseline UX Manifesto invariants
+Physical State contract for JtV. Baseline UX Manifesto invariants
 that MUST hold at all times.
 @end
 

--- a/contractiles/trust/Trustfile.a2ml
+++ b/contractiles/trust/Trustfile.a2ml
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath)
 
 @abstract:
-Trust and provenance verification for Julia The Viper.
+Trust and provenance verification for JtV.
 Maximal trust by default — LLM may read, build, test, lint, format.
 @end
 

--- a/crates/jtv-cli/Cargo.toml
+++ b/crates/jtv-cli/Cargo.toml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
-# Julia the Viper - Command Line Interface
+# JtV - Command Line Interface
 
 [package]
 name = "jtv-cli"
-description = "Command-line interface for Julia the Viper"
+description = "Command-line interface for JtV"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/crates/jtv-cli/src/main.rs
+++ b/crates/jtv-cli/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - Command Line Interface
+// JtV - Command Line Interface
 
 // Allow some clippy lints for cleaner output
 #![allow(clippy::wildcard_in_or_patterns)]
@@ -27,7 +27,7 @@ use rsr_check::RsrChecker;
 
 #[derive(Parser)]
 #[command(name = "jtv")]
-#[command(about = "Julia the Viper - Harvard Architecture Language", long_about = None)]
+#[command(about = "JtV - Harvard Architecture Language", long_about = None)]
 #[command(version)]
 struct Cli {
     #[command(subcommand)]
@@ -625,14 +625,14 @@ fn cexpr_to_sexpr(expr: &jtv_core::ControlExpr, out: &mut String) {
 }
 
 fn print_version() {
-    println!("{}", "Julia the Viper".cyan().bold());
+    println!("{}", "JtV".cyan().bold());
     println!("Version: {}", env!("CARGO_PKG_VERSION"));
     println!("Build: {}", "Rust");
     println!();
     println!("{}", "Harvard Architecture Language".green());
     println!("Makes code injection grammatically impossible");
     println!();
-    println!("Repository: https://github.com/Hyperpolymath/julia-the-viper");
+    println!("Repository: https://github.com/Hyperpolymath/jtv");
     println!("Documentation: https://docs.julia-viper.dev");
 }
 

--- a/crates/jtv-cli/src/repl.rs
+++ b/crates/jtv-cli/src/repl.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
-// SPDX-FileCopyrightText: 2025 Julia the Viper Contributors
+// SPDX-FileCopyrightText: 2025 JtV Contributors
 //
-// Julia the Viper - Interactive REPL
+// JtV - Interactive REPL
 
 use colored::*;
 use jtv_core::{parse_program, Interpreter};
@@ -128,7 +128,7 @@ impl Repl {
         );
         println!(
             "{}",
-            "║         Julia the Viper - Interactive REPL                ║".cyan()
+            "║         JtV - Interactive REPL                            ║".cyan()
         );
         println!(
             "{}",

--- a/crates/jtv-cli/src/rsr_check.rs
+++ b/crates/jtv-cli/src/rsr_check.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// SPDX-FileCopyrightText: 2025 Julia the Viper Contributors
+// SPDX-FileCopyrightText: 2025 JtV Contributors
 //
 // RSR (Rhodium Standard Repository) Compliance Checker
 

--- a/crates/jtv-core/Cargo.toml
+++ b/crates/jtv-core/Cargo.toml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Julia the Viper - Core Language Implementation
+# JtV - Core Language Implementation
 
 [package]
 name = "jtv-core"

--- a/crates/jtv-core/benches/parser_bench.rs
+++ b/crates/jtv-core/benches/parser_bench.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - Parser Benchmark
+// JtV - Parser Benchmark
 // Measures LOC/sec on synthetic JTV programs exercising the Harvard architecture
 // (data language + control language).
 

--- a/crates/jtv-core/src/ast.rs
+++ b/crates/jtv-core/src/ast.rs
@@ -1,4 +1,4 @@
-// Abstract Syntax Tree for Julia the Viper
+// Abstract Syntax Tree for JtV
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/jtv-core/src/error.rs
+++ b/crates/jtv-core/src/error.rs
@@ -1,4 +1,4 @@
-// Error handling for Julia the Viper
+// Error handling for JtV
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, JtvError>;

--- a/crates/jtv-core/src/formatter.rs
+++ b/crates/jtv-core/src/formatter.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
-// SPDX-FileCopyrightText: 2025 Julia the Viper Contributors
+// SPDX-FileCopyrightText: 2025 JtV Contributors
 //
-// Julia the Viper - Code Formatter
+// JtV - Code Formatter
 
 use crate::ast::*;
 

--- a/crates/jtv-core/src/grammar.pest
+++ b/crates/jtv-core/src/grammar.pest
@@ -1,4 +1,4 @@
-// Julia the Viper - Pest Grammar for Rust Parser
+// JtV - Pest Grammar for Rust Parser
 // Harvard Architecture: Control (Turing-complete) + Data (Total)
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/crates/jtv-core/src/interpreter.rs
+++ b/crates/jtv-core/src/interpreter.rs
@@ -1,4 +1,4 @@
-// Interpreter for Julia the Viper
+// Interpreter for JtV
 use crate::ast::*;
 use crate::coproc::CoprocNamespace;
 use crate::error::{JtvError, Result};

--- a/crates/jtv-core/src/lib.rs
+++ b/crates/jtv-core/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - Core Language Implementation
+// JtV - Core Language Implementation
 // Harvard Architecture: Control (Turing-complete) + Data (Total)
 
 // Allow some clippy lints that require significant refactoring

--- a/crates/jtv-core/src/pretty.rs
+++ b/crates/jtv-core/src/pretty.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - Pretty-Printer
+// JtV - Pretty-Printer
 // Converts AST nodes back to well-formatted JtV source code.
 // Unlike the Formatter (which parses source then reformats), the
 // pretty-printer works directly on AST nodes and supports individual

--- a/crates/jtv-core/src/purity.rs
+++ b/crates/jtv-core/src/purity.rs
@@ -1,4 +1,4 @@
-// Purity enforcement for Julia the Viper
+// Purity enforcement for JtV
 // Ensures @pure and @total functions respect their contracts
 
 use crate::ast::*;

--- a/crates/jtv-core/src/recovery.rs
+++ b/crates/jtv-core/src/recovery.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - Error Recovery Parser
+// JtV - Error Recovery Parser
 // Provides parse_recovering() which returns a partial AST alongside
 // a list of diagnostics. This enables IDE features (syntax highlighting,
 // code completion) even when the source is incomplete or malformed.

--- a/crates/jtv-core/src/reversible.rs
+++ b/crates/jtv-core/src/reversible.rs
@@ -1,4 +1,4 @@
-// Reversible computing for Julia the Viper (v2 feature)
+// Reversible computing for JtV (v2 feature)
 // Implements automatic reverse execution for reverse blocks
 
 use crate::ast::*;

--- a/crates/jtv-core/src/typechecker.rs
+++ b/crates/jtv-core/src/typechecker.rs
@@ -1,4 +1,4 @@
-// Type checker for Julia the Viper
+// Type checker for JtV
 // Implements static type checking for the 7 number systems and compound types
 
 use crate::ast::*;

--- a/crates/jtv-core/src/wasm.rs
+++ b/crates/jtv-core/src/wasm.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// WASM bindings for Julia the Viper
+// WASM bindings for JtV
 //
 // Exposes the full JtV language runtime to WebAssembly consumers:
 //   - Parsing and AST inspection

--- a/crates/jtv-core/tests/compatibility_tests.rs
+++ b/crates/jtv-core/tests/compatibility_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Version compatibility tests for Julia the Viper.
+// Version compatibility tests for JtV.
 // Verifies that serialized AST snapshots from earlier versions can still
 // be deserialized by the current code. This prevents silent data corruption
 // when AST types change.

--- a/crates/jtv-core/tests/conformance_tests.rs
+++ b/crates/jtv-core/tests/conformance_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - Conformance Suite Runner
+// JtV - Conformance Suite Runner
 // Loads .jtv files from conformance/valid/ and conformance/invalid/
 // and asserts that valid files parse successfully and invalid files
 // produce errors (either parse errors OR semantic errors like purity violations).

--- a/crates/jtv-core/tests/contract_tests.rs
+++ b/crates/jtv-core/tests/contract_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Contract and invariant tests for Julia the Viper.
+// Contract and invariant tests for JtV.
 // Verifies that declared contracts (addition-only, purity, Harvard separation,
 // reversibility) actually hold at runtime, not just at parse time.
 //

--- a/crates/jtv-core/tests/harvard_boundary_tests.rs
+++ b/crates/jtv-core/tests/harvard_boundary_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Harvard Architecture boundary tests for Julia the Viper.
+// Harvard Architecture boundary tests for JtV.
 //
 // These tests verify the fundamental JTV security property: Data Language
 // and Control Language are grammatically separated. Code injection is

--- a/crates/jtv-core/tests/parser_tests.rs
+++ b/crates/jtv-core/tests/parser_tests.rs
@@ -1,4 +1,4 @@
-// Parser tests for Julia the Viper
+// Parser tests for JtV
 use jtv_core::parse_program;
 
 #[test]

--- a/crates/jtv-core/tests/pest_rule_tests.rs
+++ b/crates/jtv-core/tests/pest_rule_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - PEG Rule-Level Tests
+// JtV - PEG Rule-Level Tests
 // Tests every individual pest grammar rule in isolation.
 
 use jtv_core::parser::{JtvParser, Rule};

--- a/crates/jtv-core/tests/property_tests.rs
+++ b/crates/jtv-core/tests/property_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Property-based tests for Julia the Viper's 7 number systems.
+// Property-based tests for JtV's 7 number systems.
 // Verifies algebraic laws (commutativity, associativity, identity) hold
 // across all number types and cross-type coercion paths.
 

--- a/crates/jtv-debug/src/main.rs
+++ b/crates/jtv-debug/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Interactive debugger for Julia the Viper with reversibility inspection
+// Interactive debugger for JtV with reversibility inspection
 
 #![forbid(unsafe_code)]
 use colored::*;
@@ -160,7 +160,7 @@ impl Debugger {
     }
 
     fn show_help(&self) {
-        println!("\n{}", "Julia the Viper Debugger Commands:".bold().cyan());
+        println!("\n{}", "JtV Debugger Commands:".bold().cyan());
         println!("  {}              - Run the loaded program", "run".green());
         println!("  {}        - Set breakpoint at line N", "break N".green());
         println!(
@@ -187,7 +187,7 @@ impl Debugger {
 }
 
 fn main() -> Result<()> {
-    println!("{}", "Julia the Viper Interactive Debugger".bold().cyan());
+    println!("{}", "JtV Interactive Debugger".bold().cyan());
     println!("{}", "Type 'help' for commands\n".yellow());
 
     let mut debugger = Debugger::new();

--- a/crates/jtv-lsp/src/main.rs
+++ b/crates/jtv-lsp/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Language Server Protocol implementation for Julia the Viper
+// Language Server Protocol implementation for JtV
 
 #![forbid(unsafe_code)]
 use jtv_core::{parser::parse_program, purity::PurityChecker, typechecker::TypeChecker};
@@ -46,7 +46,7 @@ impl LanguageServer for Backend {
 
     async fn initialized(&self, _: InitializedParams) {
         self.client
-            .log_message(MessageType::INFO, "Julia the Viper LSP initialized")
+            .log_message(MessageType::INFO, "JtV LSP initialized")
             .await;
     }
 
@@ -100,7 +100,7 @@ impl LanguageServer for Backend {
     async fn hover(&self, _params: HoverParams) -> Result<Option<Hover>> {
         Ok(Some(Hover {
             contents: HoverContents::Scalar(MarkedString::String(
-                "Julia the Viper: Reversible systems programming".to_string(),
+                "JtV: Reversible systems programming".to_string(),
             )),
             range: None,
         }))

--- a/docs/GRAMMAR_EVOLUTION.md
+++ b/docs/GRAMMAR_EVOLUTION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Julia the Viper has two distinct evolutionary stages that must NOT be conflated:
+JtV has two distinct evolutionary stages that must NOT be conflated:
 
 - **v1 (Alpha/Beta)**: Foundation - Harvard Architecture with addition-only Data Language
 - **v2 (Gamma)**: Quantum Leap - Adds reversible computing and quantum simulation

--- a/docs/QUANTUM_VISION.md
+++ b/docs/QUANTUM_VISION.md
@@ -4,7 +4,7 @@
 
 ## Executive Summary
 
-Julia the Viper v2 extends the addition-only Data Language with **reversible computing** to enable quantum algorithm simulation. This is not a gimmick - it's a natural consequence of the Harvard Architecture design.
+JtV v2 extends the addition-only Data Language with **reversible computing** to enable quantum algorithm simulation. This is not a gimmick - it's a natural consequence of the Harvard Architecture design.
 
 ## The Connection
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,8 +1,8 @@
-# Julia the Viper - Quick Start Guide
+# JtV - Quick Start Guide
 
 ## What is JtV?
 
-Julia the Viper is a programming language that makes code injection **grammatically impossible** by separating:
+JtV is a programming language that makes code injection **grammatically impossible** by separating:
 
 - **Control Language**: Loops, conditionals, I/O (Turing-complete)
 - **Data Language**: Pure expressions, addition-only (Total/provably halting)
@@ -26,8 +26,8 @@ npm install @jtv/wasm
 ### From Source
 
 ```bash
-git clone https://github.com/Hyperpolymath/julia-the-viper
-cd julia-the-viper
+git clone https://github.com/Hyperpolymath/jtv
+cd jtv
 just build
 ```
 
@@ -282,7 +282,7 @@ reverse {
 
 - **GitHub Issues**: Bug reports and feature requests
 - **Discord**: Community chat and support
-- **Stack Overflow**: Tag questions with `julia-the-viper`
+- **Stack Overflow**: Tag questions with `jtv`
 - **Documentation**: Full docs at https://docs.julia-viper.dev
 
 ## Philosophy

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# Julia the Viper - Development Roadmap
+# JtV - Development Roadmap
 
 ## Vision
 

--- a/docs/TECHNICAL_ROADMAP.md
+++ b/docs/TECHNICAL_ROADMAP.md
@@ -1,4 +1,4 @@
-# Julia the Viper - Technical Roadmap
+# JtV - Technical Roadmap
 
 ## Overview
 

--- a/docs/design-decisions/0001-coprocessor-pata-pathway.adoc
+++ b/docs/design-decisions/0001-coprocessor-pata-pathway.adoc
@@ -9,7 +9,7 @@ Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 :sectnums:
 
 [.lead]
-How Julia the Viper (JtV) admits direct coprocessor access without growing a
+How JtV admits direct coprocessor access without growing a
 GPU-style kernel backend — framed through Alfred Jarry's 'pataphysics (the
 science of the particular, of exceptions, of imaginary solutions) rather than
 conventional meta-compilation.

--- a/docs/language/reversibility/v0.2-design.adoc
+++ b/docs/language/reversibility/v0.2-design.adoc
@@ -1,6 +1,6 @@
 = Reversibility (v0.2 Design - Proposed)
 
-This document describes a proposed extension to Julia the Viper introducing
+This document describes a proposed extension to JtV introducing
 reversible execution semantics.
 
 This is a design document only. No features described here are currently

--- a/docs/reports/audit/audit-2026-04-15-post.md
+++ b/docs/reports/audit/audit-2026-04-15-post.md
@@ -1,7 +1,7 @@
-# Post-audit Status Report: julia-the-viper
+# Post-audit Status Report: jtv
 - **Date:** 2026-04-15
 - **Status:** Complete (M5 Sweep)
-- **Repo:** /var/mnt/eclipse/repos/julia-the-viper
+- **Repo:** /var/mnt/eclipse/repos/jtv
 
 ## Actions Taken
 1. Standard CI/Workflow Sweep: Added blocker workflows (`ts-blocker.yml`, `npm-bun-blocker.yml`) and updated `Justfile`.

--- a/docs/tech-debt-2026-05-26.md
+++ b/docs/tech-debt-2026-05-26.md
@@ -3,7 +3,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
 -->
 
-# Tech-Debt Audit — julia-the-viper — 2026-05-26
+# Tech-Debt Audit — jtv — 2026-05-26
 
 **Source:** estate-wide automated scan 2026-05-26.
 **Companion:** [`hyperpolymath/standards` 2026-05-26-estate-*-debt audits](https://github.com/hyperpolymath/standards/tree/main/docs/audits).

--- a/editors/jtv.tmLanguage.json
+++ b/editors/jtv.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "Julia the Viper",
+  "name": "JtV",
   "scopeName": "source.jtv",
   "fileTypes": [
     "jtv"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "julia-the-viper",
-  "displayName": "Julia the Viper",
-  "description": "Syntax highlighting and language support for Julia the Viper (.jtv files)",
+  "name": "jtv",
+  "displayName": "JtV",
+  "description": "Syntax highlighting and language support for JtV (.jtv files)",
   "version": "0.1.0",
-  "publisher": "julia-the-viper",
+  "publisher": "jtv",
   "engines": {
     "vscode": "^1.80.0"
   },
@@ -13,7 +13,7 @@
   "contributes": {
     "languages": [{
       "id": "jtv",
-      "aliases": ["Julia the Viper", "jtv"],
+      "aliases": ["JtV", "jtv"],
       "extensions": [".jtv"],
       "configuration": "./language-configuration.json"
     }],

--- a/editors/vscode/syntaxes/jtv.tmLanguage.json
+++ b/editors/vscode/syntaxes/jtv.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "Julia the Viper",
+  "name": "JtV",
   "scopeName": "source.jtv",
   "patterns": [
     {

--- a/examples/basic/01_hello_addition.jtv
+++ b/examples/basic/01_hello_addition.jtv
@@ -1,4 +1,4 @@
-// Hello World - Julia the Viper style
+// Hello World - JtV style
 // Demonstrates basic addition in the Data Language
 
 // Simple addition

--- a/examples/integrations/javascript_integration.js
+++ b/examples/integrations/javascript_integration.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Julia the Viper - JavaScript Integration Example
+ * JtV - JavaScript Integration Example
  * Demonstrates using JtV WASM module from Node.js
  */
 
@@ -249,7 +249,7 @@ function reversibleComputingExample() {
 // Main execution
 async function main() {
   console.log("=" . repeat(60));
-  console.log("Julia the Viper - JavaScript Integration Examples");
+  console.log("JtV - JavaScript Integration Examples");
   console.log("=" . repeat(60));
 
   basicSecurityExample();

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 {
-  description = "Julia the Viper - Harvard Architecture language making code injection grammatically impossible";
+  description = "JtV - Harvard Architecture language making code injection grammatically impossible";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -43,7 +43,7 @@
           default = self.packages.${system}.jtv;
 
           jtv = pkgs.rustPlatform.buildRustPackage {
-            pname = "julia-the-viper";
+            pname = "jtv";
             version = "0.1.0";
 
             src = ./.;
@@ -56,7 +56,7 @@
 
             meta = with pkgs.lib; {
               description = "Harvard Architecture language making code injection grammatically impossible";
-              homepage = "https://github.com/hyperpolymath/julia-the-viper";
+              homepage = "https://github.com/hyperpolymath/jtv";
               license = with licenses; [ gpl3Plus ];
               maintainers = [ ];
             };
@@ -64,7 +64,7 @@
 
           # WASM build
           jtv-wasm = pkgs.stdenv.mkDerivation {
-            pname = "julia-the-viper-wasm";
+            pname = "jtv-wasm";
             version = "0.1.0";
 
             src = ./.;
@@ -113,7 +113,7 @@
           ]);
 
           shellHook = ''
-            echo "🐍 Julia the Viper Development Environment"
+            echo "🐍 JtV Development Environment"
             echo ""
             echo "Available commands:"
             echo "  just --list     # Show all build commands"

--- a/fuzz/fuzz_targets/fuzz_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_parser.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //
-// Julia the Viper - Parser Fuzzer
+// JtV - Parser Fuzzer
 // Feeds random UTF-8 through the pest parser to detect panics, hangs,
 // and memory-safety issues. The parser must NEVER panic on invalid
 // input; it should always return a clean error.

--- a/guix.scm
+++ b/guix.scm
@@ -1,5 +1,5 @@
 ; SPDX-License-Identifier: MPL-2.0
-;; guix.scm — GNU Guix package definition for julia-the-viper
+;; guix.scm — GNU Guix package definition for jtv
 ;; Usage: guix shell -f guix.scm
 
 (use-modules (guix packages)
@@ -7,12 +7,12 @@
              (guix licenses))
 
 (package
-  (name "julia-the-viper")
+  (name "jtv")
   (version "0.1.0")
   (source #f)
   (build-system gnu-build-system)
-  (synopsis "julia-the-viper")
-  (description "julia-the-viper — part of the hyperpolymath ecosystem.")
-  (home-page "https://github.com/hyperpolymath/julia-the-viper")
+  (synopsis "jtv")
+  (description "jtv — part of the hyperpolymath ecosystem.")
+  (home-page "https://github.com/hyperpolymath/jtv")
   (license ((@@ (guix licenses) license) "MPL-2.0"
              "https://github.com/hyperpolymath/palimpsest-license")))

--- a/jtv_proofs/JtvCore.lean
+++ b/jtv_proofs/JtvCore.lean
@@ -1,5 +1,5 @@
 /-
-  Julia the Viper - Denotational Semantics Core Definitions
+  JtV - Denotational Semantics Core Definitions
 
   This file defines the semantic domains and evaluation functions for JtV's
   Data Language (the Total, addition-only expression sublanguage).

--- a/jtv_proofs/JtvEcho.lean
+++ b/jtv_proofs/JtvEcho.lean
@@ -1,5 +1,5 @@
 /-
-  Julia the Viper — Echo Types: Structured Loss / Non-Total Erasure
+  JtV — Echo Types: Structured Loss / Non-Total Erasure
 
   This module formalises JtV's *Echo system* (spec v2, §8–9, §12) and aligns it
   with the `echo-types` Agda library (hyperpolymath/echo-types) and its

--- a/jtv_proofs/JtvExtended.lean
+++ b/jtv_proofs/JtvExtended.lean
@@ -1,5 +1,5 @@
 /-
-  Julia the Viper - Extended Formal Proofs
+  JtV - Extended Formal Proofs
 
   This file contains additional theorems and lemmas extending the core
   proof suite for comprehensive academic verification.

--- a/jtv_proofs/JtvOperational.lean
+++ b/jtv_proofs/JtvOperational.lean
@@ -1,5 +1,5 @@
 /-
-  Julia the Viper - Operational Semantics
+  JtV - Operational Semantics
 
   This file defines small-step and big-step operational semantics for JtV,
   complementing the denotational semantics in JtvCore.lean.

--- a/jtv_proofs/JtvSecurity.lean
+++ b/jtv_proofs/JtvSecurity.lean
@@ -1,5 +1,5 @@
 /-
-  Julia the Viper - Security Properties
+  JtV - Security Properties
 
   This file formalizes the security guarantees of JtV's Harvard Architecture:
   1. Code injection impossibility (grammatical guarantee)
@@ -129,7 +129,7 @@ theorem no_control_to_data_flow (s : ControlStmt) :
 /-
   **AOLD Philosophy**:
 
-  Julia the Viper implements Aspect-Oriented Language Development at the
+  JtV implements Aspect-Oriented Language Development at the
   grammar level. Traditional AOP separates cross-cutting concerns (logging,
   security, transactions) from business logic at runtime or compile-time.
 

--- a/jtv_proofs/JtvTheorems.lean
+++ b/jtv_proofs/JtvTheorems.lean
@@ -1,5 +1,5 @@
 /-
-  Julia the Viper - Denotational Semantics Theorems
+  JtV - Denotational Semantics Theorems
 
   This file contains mechanized proofs of the key properties of JtV's
   Data Language, including:

--- a/jtv_proofs/JtvTypes.lean
+++ b/jtv_proofs/JtvTypes.lean
@@ -1,5 +1,5 @@
 /-
-  Julia the Viper - Type System Formalization
+  JtV - Type System Formalization
 
   This file defines the type system for JtV including:
   1. Type definitions (7 number systems + compound types)

--- a/llm-warmup-dev.md
+++ b/llm-warmup-dev.md
@@ -1,6 +1,6 @@
-# LLM Warmup — julia-the-viper (Developer)
+# LLM Warmup — jtv (Developer)
 
-## What is julia-the-viper?
+## What is jtv?
 See README.adoc for overview.
 
 ## Key Commands

--- a/llm-warmup-user.md
+++ b/llm-warmup-user.md
@@ -1,6 +1,6 @@
-# LLM Warmup — julia-the-viper (User)
+# LLM Warmup — jtv (User)
 
-## What is julia-the-viper?
+## What is jtv?
 See README.adoc for overview.
 
 ## Key Commands

--- a/packages/jtv-analyzer/src/Main.res
+++ b/packages/jtv-analyzer/src/Main.res
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // hypatia:ignore cicd_rules/banned_language_file — legacy ReScript pending AffineScript migration
-// Julia the Viper - Code Analyzer for Python/JavaScript/Ruby
+// JtV - Code Analyzer for Python/JavaScript/Ruby
 // Analyzes legacy code for termination guarantees, purity, and complexity
 
 /** Supported analysis target languages */

--- a/playground/Justfile
+++ b/playground/Justfile
@@ -24,7 +24,7 @@ demo:
 
 # Show help and available recipes
 help:
-    @echo "JTV Playground - Julia-the-Viper Workbench"
+    @echo "JTV Playground - JtV Workbench"
     @echo "==========================================="
     @echo ""
     @echo "Golden Path (f0):"
@@ -149,7 +149,7 @@ version:
     @echo "JTV Playground v0.1.0-f0"
     @echo ""
     @echo "Milestone: f0 (scope control)"
-    @echo "Focus:     Julia-the-Viper language workbench"
+    @echo "Focus:     JtV language workbench"
 
 # ==============================================================================
 # CI/CD INTEGRATION

--- a/playground/README.adoc
+++ b/playground/README.adoc
@@ -9,7 +9,7 @@ image:https://img.shields.io/badge/Docs-CC--BY--SA--4.0-blue.svg[Docs: CC-BY-SA-
 
 // SPDX-License-Identifier: CC-BY-SA-4.0
 
-*Controlled experimentation workbench for Julia-the-Viper (JTV) language development*
+*Controlled experimentation workbench for JtV language development*
 
 image:https://img.shields.io/badge/Language-JTV-red[JTV]
 image:https://img.shields.io/badge/Milestone-f0-green[f0]
@@ -18,11 +18,11 @@ toc::[]
 
 == Overview
 
-This repository is a **controlled playground** for JTV (Julia-the-Viper) language development. Per the ANCHOR scope policy, all activities are scoped exclusively to JTV language, tooling, and UX experiments.
+This repository is a **controlled playground** for JtV language development. Per the ANCHOR scope policy, all activities are scoped exclusively to JTV language, tooling, and UX experiments.
 
 === What is JTV?
 
-Julia-the-Viper is a systems programming language designed for Harvard architecture embedded systems where code and data live in separate memory spaces.
+JtV is a systems programming language designed for Harvard architecture embedded systems where code and data live in separate memory spaces.
 
 Key features:
 

--- a/playground/jtv/README.adoc
+++ b/playground/jtv/README.adoc
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: CC-BY-SA-4.0
 
-*Controlled experimentation workbench for Julia-the-Viper language development*
+*Controlled experimentation workbench for JtV language development*
 
 image:https://img.shields.io/badge/Language-JTV-red[JTV]
 image:https://img.shields.io/badge/Code-MPL--2.0-blue.svg[Code: MPL-2.0,link="../../LICENSE"]
@@ -17,7 +17,7 @@ toc::[]
 
 This is the **only area that may grow** in the jtv-playground repository (per ANCHOR scope policy).
 
-Julia-the-Viper (JTV) is a systems programming language designed for Harvard architecture processors where code and data live in separate memory spaces.
+JtV is a systems programming language designed for Harvard architecture processors where code and data live in separate memory spaces.
 
 == Directory Structure
 

--- a/playground/jtv/spec/SYNTAX.adoc
+++ b/playground/jtv/spec/SYNTAX.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 == Overview
 
-Julia-the-Viper (JTV) is a systems programming language for Harvard architecture embedded systems.
+JtV is a systems programming language for Harvard architecture embedded systems.
 
 == Lexical Structure
 

--- a/playground/jtv/tools/demo.sh
+++ b/playground/jtv/tools/demo.sh
@@ -9,7 +9,7 @@ set -e
 SAMPLES_DIR="${1:-jtv/samples}"
 
 echo "=============================================="
-echo "  Julia-the-Viper (JTV) Language Demo"
+echo "  JtV Language Demo"
 echo "  Harvard Architecture Systems Programming"
 echo "=============================================="
 echo ""

--- a/references.bib
+++ b/references.bib
@@ -1,6 +1,6 @@
 % SPDX-License-Identifier: MPL-2.0
 % Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
-% References for Julia-the-Viper: Harvard-architecture language separating
+% References for JtV: Harvard-architecture language separating
 % data (total, addition-only) from control (Turing-complete)
 
 @article{aiken1937design,
@@ -8,7 +8,7 @@
   title     = {Proposed Automatic Calculating Machine},
   journal   = {IEEE Spectrum (reprinted)},
   year      = {1937},
-  note      = {Original Harvard architecture concept; separation of instruction and data stores inspires Julia-the-Viper dual-plane design}
+  note      = {Original Harvard architecture concept; separation of instruction and data stores inspires JtV dual-plane design}
 }
 
 @inproceedings{coquand1986calculus,
@@ -19,7 +19,7 @@
   number    = {2--3},
   pages     = {95--120},
   year      = {1988},
-  note      = {Total dependently-typed calculus; theoretical basis for Julia-the-Viper data plane totality}
+  note      = {Total dependently-typed calculus; theoretical basis for JtV data plane totality}
 }
 
 @article{turner2004total,
@@ -30,7 +30,7 @@
   number    = {7},
   pages     = {751--768},
   year      = {2004},
-  note      = {Total programming manifesto; direct influence on Julia-the-Viper addition-only data plane}
+  note      = {Total programming manifesto; direct influence on JtV addition-only data plane}
 }
 
 @book{pierce2002types,
@@ -47,7 +47,7 @@
   booktitle = {Proceedings of the 31st ACM SIGPLAN-SIGACT Symposium on Principles of Programming Languages},
   pages     = {111--122},
   year      = {2004},
-  note      = {PEG parsing formalism; basis for Julia-the-Viper pest-based parser}
+  note      = {PEG parsing formalism; basis for JtV pest-based parser}
 }
 
 @techreport{haas2017webassembly,
@@ -56,7 +56,7 @@
   booktitle = {Proceedings of the 38th ACM SIGPLAN Conference on Programming Language Design and Implementation},
   pages     = {185--200},
   year      = {2017},
-  note      = {WebAssembly specification and design; Julia-the-Viper compilation target}
+  note      = {WebAssembly specification and design; JtV compilation target}
 }
 
 @article{turing1937computable,
@@ -67,7 +67,7 @@
   number    = {1},
   pages     = {230--265},
   year      = {1937},
-  note      = {Turing completeness; defines the computational power of Julia-the-Viper control plane}
+  note      = {Turing completeness; defines the computational power of JtV control plane}
 }
 
 @article{bove2009brief,
@@ -93,7 +93,7 @@
   author    = {John von Neumann},
   title     = {First Draft of a Report on the {EDVAC}},
   year      = {1945},
-  note      = {Von Neumann architecture (unified memory); contrasts with Harvard separation that Julia-the-Viper adopts at the language level}
+  note      = {Von Neumann architecture (unified memory); contrasts with Harvard separation that JtV adopts at the language level}
 }
 
 @inproceedings{rossberg2023wasm,
@@ -101,7 +101,7 @@
   title     = {The {WebAssembly} Type System},
   booktitle = {WebAssembly Community Group},
   year      = {2023},
-  note      = {WASM type system evolution; relevant to typed compilation target for Julia-the-Viper}
+  note      = {WASM type system evolution; relevant to typed compilation target for JtV}
 }
 
 @article{church1936unsolvable,

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # SPDX-License-Identifier: MPL-2.0
-# setup.sh — Universal setup script for julia-the-viper
+# setup.sh — Universal setup script for jtv
 #
 # Detects your shell, platform, and installs prerequisites.
 # Then hands off to `just setup` for project-specific configuration.
 #
 # Usage:
-#   curl -fsSL -o setup.sh https://raw.githubusercontent.com/hyperpolymath/julia-the-viper/main/setup.sh && sh ./setup.sh   # download, inspect, then run
+#   curl -fsSL -o setup.sh https://raw.githubusercontent.com/hyperpolymath/jtv/main/setup.sh && sh ./setup.sh   # download, inspect, then run
 #   # or after cloning:
 #   ./setup.sh
 #
@@ -170,7 +170,7 @@ install_just() {
 
 # ── Main ──
 main() {
-    printf "%s=== julia-the-viper Setup ===%s\n\n" "$BOLD" "$RESET"
+    printf "%s=== jtv Setup ===%s\n\n" "$BOLD" "$RESET"
 
     # Detect environment
     SHELL_NAME=$(detect_shell)
@@ -201,8 +201,8 @@ main() {
     # Step 2: Check if we're in the repo directory
     if [ ! -f "Justfile" ] && [ ! -f "justfile" ]; then
         warn "Not in a repo directory (no Justfile found)"
-        info "Clone first: git clone https://github.com/hyperpolymath/julia-the-viper.git"
-        info "Then: cd julia-the-viper && ./setup.sh"
+        info "Clone first: git clone https://github.com/hyperpolymath/jtv.git"
+        info "Then: cd jtv && ./setup.sh"
         exit 1
     fi
 

--- a/shared/grammar/jtv.ebnf
+++ b/shared/grammar/jtv.ebnf
@@ -1,4 +1,4 @@
-(* Julia the Viper - Complete EBNF Grammar *)
+(* JtV - Complete EBNF Grammar *)
 (* Harvard Architecture: Control (Turing-complete) + Data (Total/provably halting) *)
 
 (* ===== PROGRAM STRUCTURE ===== *)

--- a/spec/LANGUAGE_SPECIFICATION.md
+++ b/spec/LANGUAGE_SPECIFICATION.md
@@ -1,4 +1,4 @@
-# Julia the Viper Language Specification
+# JtV Language Specification
 
 **Version:** 1.0.0
 **Date:** 2026-03-14
@@ -24,7 +24,7 @@
 
 ## 1. Introduction
 
-Julia the Viper (JtV) is a statically typed, interpreted language with a Rust-based interpreter and a pest-based parser. It follows a Harvard architecture, separating code and data to enhance security and predictability.
+JtV is a statically typed, interpreted language with a Rust-based interpreter and a pest-based parser. It follows a Harvard architecture, separating code and data to enhance security and predictability.
 
 ### Key Features
 - **Harvard Architecture**: Separation of code (Control Language) and data (Data Language).

--- a/spec/README.adoc
+++ b/spec/README.adoc
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // @taxonomy: spec/index
-= julia-the-viper — Specification Directory
+= jtv — Specification Directory
 :toc:
 
 == Overview
 
-This directory contains the canonical language/query specification files for julia-the-viper.
+This directory contains the canonical language/query specification files for jtv.
 
 == Contents
 
 === grammar.ebnf
-The canonical EBNF grammar for julia-the-viper.
+The canonical EBNF grammar for jtv.
 Copied from the original source location; the original is preserved.
 
 === SPEC.core.scm

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -1,7 +1,7 @@
 (* SPDX-License-Identifier: MPL-2.0 *)
 (* Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk> *)
 (* @taxonomy: spec/grammar *)
-(* Julia the Viper - Complete EBNF Grammar *)
+(* JtV - Complete EBNF Grammar *)
 (* Harvard Architecture: Control (Turing-complete) + Data (Total/provably halting) *)
 
 (* ===== PROGRAM STRUCTURE ===== *)

--- a/spec/jtv_v2_type_system.adoc
+++ b/spec/jtv_v2_type_system.adoc
@@ -1,4 +1,4 @@
-= Julia the Viper Type System Specification (V2 Draft)
+= JtV Type System Specification (V2 Draft)
 :version: 2.0.0-draft
 :date: 2026-04-16
 
@@ -7,7 +7,7 @@ Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath)
 
 == 0. Design Goals
 
-This document defines Version 2 of the Julia the Viper (JtV) type system.
+This document defines Version 2 of the JtV type system.
 
 Goals:
 

--- a/spec/jtv_v2_type_system_corrected.adoc
+++ b/spec/jtv_v2_type_system_corrected.adoc
@@ -1,4 +1,4 @@
-= Julia the Viper Type System Specification (V2 Corrected Draft)
+= JtV Type System Specification (V2 Corrected Draft)
 :version: 2.0.0-draft
 :date: 2026-04-16
 

--- a/spec/system-specs.md
+++ b/spec/system-specs.md
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: CC-BY-SA-4.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
-# Julia the Viper — System Specifications
+# JtV — System Specifications
 
-Julia the Viper (JtV) is an interpreted language with a Rust interpreter and
+JtV is an interpreted language with a Rust interpreter and
 pest-based parser, following a Harvard architecture where code and data are
 separated.
 

--- a/spec/type-system.md
+++ b/spec/type-system.md
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: CC-BY-SA-4.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
-# Julia-the-Viper Type System Specification
+# JtV Type System Specification
 
 **Version:** 1.0.0
 **Date:** 2026-03-14

--- a/src/abi/Types.idr
+++ b/src/abi/Types.idr
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: MPL-2.0
 -- Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath)
--- Julia-the-Viper: Harvard Architecture Safety Proofs
+-- JtV: Harvard Architecture Safety Proofs
 
 module Types
 

--- a/stapeln.toml
+++ b/stapeln.toml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
-# stapeln.toml — Layer-based container build for julia-the-viper
+# stapeln.toml — Layer-based container build for jtv
 #
 # stapeln builds containers as composable layers (German: "to stack").
 # Each layer is independently cacheable, verifiable, and signable.
 
 [metadata]
-name = "julia-the-viper"
+name = "jtv"
 version = "0.1.0"
-description = "julia the viper"
+description = "JtV"
 author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>"
 license = "MPL-2.0"
 registry = "ghcr.io/hyperpolymath"
@@ -32,7 +32,7 @@ packages = ["rust", "build-base", "openssl-dev"]
 cache = true
 
 [layers.build]
-description = "julia-the-viper build"
+description = "jtv build"
 extends = "toolchain"
 commands = ["cargo build --release"]
 
@@ -43,7 +43,7 @@ packages = ["ca-certificates", "curl"]
 copy-from = [
     { layer = "build", src = "/app/", dst = "/app/" },
 ]
-entrypoint = ["/app/target/release/julia-the-viper"]
+entrypoint = ["/app/target/release/jtv"]
 user = "nonroot"
 
 # ── Security ───────────────────────────────────────────────────

--- a/verification/README.adoc
+++ b/verification/README.adoc
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // @taxonomy: verification/index
-= julia-the-viper — Verification Directory
+= jtv — Verification Directory
 :toc:
 
 == Overview
 
-Unified verification gateway for julia-the-viper. Each subdirectory is a symlink
+Unified verification gateway for jtv. Each subdirectory is a symlink
 to the actual location, providing a single entry point for all verification.
 
 == Structure

--- a/viper-pkg/src/registry.jl
+++ b/viper-pkg/src/registry.jl
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
-const REGISTRY_URL = "https://packages.julia-the-viper.dev/api/v1"
+const REGISTRY_URL = "https://packages.jtv.dev/api/v1"
 const FALLBACK_MODE = :git  # Use git until registry deployed
 
 """

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,6 @@
-# Julia the Viper VSCode Extension
+# JtV VSCode Extension
 
-Language support for Julia the Viper - a reversible systems programming language with purity guarantees.
+Language support for JtV - a reversible systems programming language with purity guarantees.
 
 ## Features
 
@@ -14,7 +14,7 @@ Language support for Julia the Viper - a reversible systems programming language
 
 ## Requirements
 
-- Julia the Viper toolchain installed (`jtv-cli`, `jtv-lsp`, `jtv-debug`)
+- JtV toolchain installed (`jtv-cli`, `jtv-lsp`, `jtv-debug`)
 - VSCode 1.80.0 or higher
 
 ## Extension Settings
@@ -32,7 +32,7 @@ This extension contributes the following settings:
 
 ## Language Features
 
-Julia the Viper provides:
+JtV provides:
 - **Reversibility**: All computations are reversible
 - **Purity tracking**: `@total` and `@pure` annotations with verification
 - **Formal verification**: Hindley-Milner type system with extensions
@@ -40,7 +40,7 @@ Julia the Viper provides:
 
 ## Installation
 
-1. Install Julia the Viper toolchain
+1. Install JtV toolchain
 2. Install this extension from VSCode marketplace or `.vsix`
 3. Open a `.jtv` file to activate the extension
 
@@ -51,7 +51,7 @@ cd vscode-extension
 npm install
 npm run compile
 npm run package
-code --install-extension julia-the-viper-0.1.0.vsix
+code --install-extension jtv-0.1.0.vsix
 ```
 
 ## License

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "julia-the-viper",
-  "displayName": "Julia the Viper",
-  "description": "Language support for Julia the Viper - reversible systems programming",
+  "name": "jtv",
+  "displayName": "JtV",
+  "description": "Language support for JtV - reversible systems programming",
   "version": "0.1.0",
   "publisher": "hyperpolymath",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hyperpolymath/julia-the-viper"
+    "url": "https://github.com/hyperpolymath/jtv"
   },
   "engines": {
     "vscode": "^1.80.0"
@@ -20,7 +20,7 @@
     "languages": [
       {
         "id": "jtv",
-        "aliases": ["Julia the Viper", "jtv"],
+        "aliases": ["JtV", "jtv"],
         "extensions": [".jtv"],
         "configuration": "./language-configuration.json"
       }
@@ -47,7 +47,7 @@
       }
     ],
     "configuration": {
-      "title": "Julia the Viper",
+      "title": "JtV",
       "properties": {
         "jtv.lsp.path": {
           "type": "string",

--- a/vscode-extension/src/Extension.res
+++ b/vscode-extension/src/Extension.res
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // hypatia:ignore cicd_rules/banned_language_file — legacy ReScript pending AffineScript migration
-// Julia the Viper - VS Code Extension
+// JtV - VS Code Extension
 // Provides LSP client, run/debug/format commands for .jtv files
 
 /** VS Code API bindings */
@@ -78,7 +78,7 @@ let runFile = (): unit => {
   | None => Vscode.showErrorMessage("No active editor")
   | Some(editor) => {
       let filePath = Vscode.getDocument(editor).uri.fsPath
-      let terminal = Vscode.createTerminal("Julia the Viper")
+      let terminal = Vscode.createTerminal("JtV")
       Vscode.show(terminal)
       Vscode.sendText(terminal, `jtv-cli run "${filePath}"`)
     }
@@ -113,7 +113,7 @@ let formatFile = (): unit => {
 
 /** Activate the extension: start LSP client and register commands */
 let activate = (context: Vscode.extensionContext): unit => {
-  Js.log("Julia the Viper extension activated")
+  Js.log("JtV extension activated")
 
   let config = Vscode.getConfiguration("jtv")
   let lspPath = switch Vscode.get(config, "lsp.path") {
@@ -135,7 +135,7 @@ let activate = (context: Vscode.extensionContext): unit => {
 
   let lspClient = LanguageClient.make(
     "jtv",
-    "Julia the Viper Language Server",
+    "JtV Language Server",
     serverOptions,
     clientOptions,
   )

--- a/web/Main.res
+++ b/web/Main.res
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // hypatia:ignore cicd_rules/banned_language_file — legacy ReScript pending AffineScript migration
-// Julia the Viper - Web module entry point
+// JtV - Web module entry point
 
 /** Add two numbers together.
  * The fundamental operation in JtV's addition-only Data Language.

--- a/web/MainTest.res
+++ b/web/MainTest.res
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // hypatia:ignore cicd_rules/banned_language_file — legacy ReScript pending AffineScript migration
-// Julia the Viper - Web module tests
+// JtV - Web module tests
 
 /** Deno test runner FFI binding */
 @module("Deno") @val

--- a/web/Server.res
+++ b/web/Server.res
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // hypatia:ignore cicd_rules/banned_language_file — legacy ReScript pending AffineScript migration
-// Deno server for Julia the Viper PWA
+// Deno server for JtV PWA
 
 /** Deno HTTP request type */
 type request = {url: string}
@@ -59,7 +59,7 @@ let handler = (req: request): response => {
 let () = {
   serve({port: port}, handler)
   Js.log(
-    "Julia the Viper PWA server running at http://localhost:" ++
+    "JtV PWA server running at http://localhost:" ++
     Belt.Int.toString(port) ++
     "/",
   )

--- a/web/index.html
+++ b/web/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Julia the Viper - Harvard Architecture language playground">
+  <meta name="description" content="JtV - Harvard Architecture language playground">
   <meta name="theme-color" content="#2196f3">
-  <title>Julia the Viper Playground</title>
+  <title>JtV Playground</title>
   <link rel="manifest" href="/manifest.json">
   <style>
     * {
@@ -172,14 +172,14 @@
 </head>
 <body>
   <header>
-    <h1>🐍 Julia the Viper Playground</h1>
+    <h1>🐍 JtV Playground</h1>
     <p class="tagline">"It's basically the same thing as an adder"</p>
   </header>
 
   <main>
     <div class="panel">
       <h2>📝 Code Editor</h2>
-      <textarea id="editor" placeholder="Write your Julia the Viper code here...
+      <textarea id="editor" placeholder="Write your JtV code here...
 
 Example:
 Control {
@@ -200,7 +200,7 @@ Control {
   </main>
 
   <footer>
-    <p>Made with ❤️ by <a href="https://github.com/hyperpolymath/julia-the-viper" target="_blank">hyperpolymath</a> | Licensed under MPL-2.0</p>
+    <p>Made with ❤️ by <a href="https://github.com/hyperpolymath/jtv" target="_blank">hyperpolymath</a> | Licensed under MPL-2.0</p>
   </footer>
 
   <script type="module">

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Julia the Viper Playground",
+  "name": "JtV Playground",
   "short_name": "JtV Playground",
   "description": "Harvard Architecture language with provable termination guarantees",
   "start_url": "/",

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Service Worker for Julia the Viper PWA
+// Service Worker for JtV PWA
 
 const CACHE_NAME = 'jtv-v1';
 const urlsToCache = [

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -3,13 +3,13 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 -->
 
-# Julia the Viper Wiki
+# JtV Wiki
 
-Welcome to the Julia the Viper documentation wiki.
+Welcome to the JtV documentation wiki.
 
 ## What is JtV?
 
-**Julia the Viper** is a Harvard Architecture programming language that makes code injection **grammatically impossible**. Named after mathematician Julia Robinson, it separates:
+**JtV** is a Harvard Architecture programming language that makes code injection **grammatically impossible**. Named after mathematician Julia Robinson, it separates:
 
 - **Data Language** (Total/Decidable): Addition-only expressions that always halt
 - **Control Language** (Turing-complete): Imperative statements with loops and I/O
@@ -85,7 +85,7 @@ JtV makes injection **grammatically impossible**:
 
 ## Resources
 
-- [GitHub Repository](https://github.com/hyperpolymath/julia-the-viper)
+- [GitHub Repository](https://github.com/hyperpolymath/jtv)
 - [Technical Roadmap](../docs/TECHNICAL_ROADMAP.md)
 - [CHANGELOG](../CHANGELOG.md)
 - [License](../LICENSE.txt)

--- a/wiki/language/Harvard-Architecture.md
+++ b/wiki/language/Harvard-Architecture.md
@@ -7,7 +7,7 @@ Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk
 
 ## Overview
 
-Julia the Viper implements a **Harvard Architecture** at the language level, separating code into two distinct sublanguages:
+JtV implements a **Harvard Architecture** at the language level, separating code into two distinct sublanguages:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/wiki/reference/Grammar.md
+++ b/wiki/reference/Grammar.md
@@ -5,7 +5,7 @@ Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk
 
 # JtV Grammar Reference
 
-Complete EBNF grammar specification for Julia the Viper.
+Complete EBNF grammar specification for JtV.
 
 ## Notation
 

--- a/wiki/tooling/CLI.md
+++ b/wiki/tooling/CLI.md
@@ -5,7 +5,7 @@ Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk
 
 # JtV Command Line Interface
 
-The `jtv` CLI is the primary tool for working with Julia the Viper programs.
+The `jtv` CLI is the primary tool for working with JtV programs.
 
 ## Installation
 

--- a/wiki/tooling/LSP.md
+++ b/wiki/tooling/LSP.md
@@ -39,7 +39,7 @@ The JtV LSP provides IDE integration for editors supporting the Language Server 
 
 ### VS Code
 
-Install the "Julia the Viper" extension from the marketplace:
+Install the "JtV" extension from the marketplace:
 
 ```bash
 code --install-extension hyperpolymath.jtv-vscode

--- a/wiki/tutorials/Getting-Started.md
+++ b/wiki/tutorials/Getting-Started.md
@@ -3,9 +3,9 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 -->
 
-# Getting Started with Julia the Viper
+# Getting Started with JtV
 
-Welcome to Julia the Viper (JtV), a security-focused programming language that makes code injection **grammatically impossible**.
+Welcome to JtV, a security-focused programming language that makes code injection **grammatically impossible**.
 
 ## What is JtV?
 
@@ -32,8 +32,8 @@ jtv --version
 
 ```bash
 # Clone the repository
-git clone https://github.com/hyperpolymath/julia-the-viper.git
-cd julia-the-viper
+git clone https://github.com/hyperpolymath/jtv.git
+cd jtv
 
 # Build with Cargo
 cargo build --release
@@ -286,7 +286,7 @@ total = price1 + price2  // 118/100 = $1.18 exactly
 ## Getting Help
 
 - **Documentation**: This wiki
-- **Issues**: [GitHub Issues](https://github.com/hyperpolymath/julia-the-viper/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/hyperpolymath/julia-the-viper/discussions)
+- **Issues**: [GitHub Issues](https://github.com/hyperpolymath/jtv/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/hyperpolymath/jtv/discussions)
 
 Welcome to secure programming with JtV!


### PR DESCRIPTION
Renames the project **Julia the Viper → JtV** throughout, so the "Julia" no longer reads — to people or bots — as the Julia programming language.

> ⚠️ **Manual step required before merge.** The GitHub repo itself must be renamed (`Settings → General → Repository name → jtv`, or `gh repo rename jtv`) — I have no API for that. GitHub then auto-redirects old URLs (web/clone/API) and renames the wiki. **Merge this PR *after* the rename** so the new `…/jtv` URLs in here resolve. One hard rule: never re-create a repo named `julia-the-viper` afterwards — that's the only thing that kills the redirects.

### What changed (140 files)
- **Slug `julia-the-viper → jtv`:** every URL, manifest (`Cargo.toml` `repository`, `guix.scm`, `flake.nix`, `stapeln.toml`, `package.json`), CI, `.well-known/security.txt`, `FUNDING.yml`, `.machine_readable/*`, README badges; `git mv editors/julia-the-viper.tmLanguage.json → editors/jtv.tmLanguage.json` (+ referrers).
- **Prose `Julia the Viper` / `Julia-the-Viper → JtV`:** docs, specs, academic papers, Lean/Idris headers, source comments, wiki, playground.
- **Etymology kept as a footnote** (`README.adoc`, `CLAUDE.md`): records that JtV was formerly *Julia the Viper* — honouring mathematician **Julia Robinson** and the "adder" pun — and *why* it was renamed.
- Repadded the REPL ASCII banner box after the shorter name.

### Deliberately left
The all-caps acronym `JTV` (carries no "Julia" confusion), the ERC-20 example token symbol `"JTV"`, and the `DESIGN-JTV-V2-REVERSIBILITY.md` filename. Say the word if you want `JTV → JtV` normalised too.

### Verified
`cargo build --workspace` + `cargo test` green (127 lib + integration suites); **0** residual `julia-the-viper` / `Julia the Viper` except the 3 intentional etymology footnotes.

### Still yours, externally (nothing I can reach)
crates.io metadata if a crate is published, a Pages custom domain if set, links on your own sites. **Companion PR** in `hyperpolymath/nextgen-languages` renames the submodule that depends on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742)_