### PR TITLE
chore(ci): normalize standards-reusable wrapper headers to MPL-2.0

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 name: Governance
 
 on:

--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 name: Hypatia Security Scan
 
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 name: OSSF Scorecard
 
 on:


### PR DESCRIPTION
## What

The three standards-reusable wrapper workflows adopted in `5d49228` carried `SPDX-License-Identifier: PMPL-1.0-or-later`, regressing the MPL-2.0 estate license policy (gap-006). This normalizes all three to `MPL-2.0`:

- `.github/workflows/hypatia-scan.yml`
- `.github/workflows/scorecard.yml`
- `.github/workflows/governance.yml`

Three-line diff (SPDX identifier only); no PMPL identifiers remain in `.github/workflows/`.

## Out of scope (separate root cause)

The **Hypatia CI failure** seen on the prior PR is a *different* problem and is **not fixed here**: the `scan` job fails because the reusable it calls pins an unresolvable action —

```
##[error]Unable to resolve action `actions/cache@d4373f267a887d77f9eb0683a479ec60b1fe5b2b`, unable to find version
```

That pin lives inside `hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@5a93d9d…`, which is **outside this session's repo scope**. The fix must be made there: re-pin `actions/cache` to a current valid `v4` release SHA. This wrapper (`hypatia-scan.yml`) is just a one-line `uses:` caller and is correct apart from the license header fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJmfoz1ZS1Pejy9LLMY742)_